### PR TITLE
Add Finance analytics, UX improvements & Excel export

### DIFF
--- a/DailyPlanner/Converters/FinanceConverters.cs
+++ b/DailyPlanner/Converters/FinanceConverters.cs
@@ -102,6 +102,40 @@ public sealed class IntEqualConverter : MarkupExtension, IValueConverter
     public override object ProvideValue(IServiceProvider serviceProvider) => this;
 }
 
+/// <summary>Calculates bar width as proportion of total (max 600px).</summary>
+public sealed class CategoryBarWidthConverter : MarkupExtension, IMultiValueConverter
+{
+    private const double MaxWidth = 600;
+
+    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (values.Length >= 2 && values[0] is decimal amount && values[1] is decimal total && total > 0)
+            return Math.Max(4, (double)(amount / total) * MaxWidth);
+        return 4.0;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+}
+
+/// <summary>Converts decimal amount to bar height (max 80px, log-scaled).</summary>
+public sealed class TrendBarHeightConverter : MarkupExtension, IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is decimal d && d > 0)
+            return Math.Min(80, Math.Max(4, Math.Log10((double)d + 1) * 20));
+        return 4.0;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+}
+
 /// <summary>Shows element only when int == parameter.</summary>
 public sealed class IntToVisibilityConverter : MarkupExtension, IValueConverter
 {

--- a/DailyPlanner/Services/ExportService.cs
+++ b/DailyPlanner/Services/ExportService.cs
@@ -1,5 +1,7 @@
+using System.Collections.ObjectModel;
 using ClosedXML.Excel;
 using DailyPlanner.Models;
+using DailyPlanner.ViewModels;
 
 namespace DailyPlanner.Services;
 
@@ -138,6 +140,134 @@ public static class ExportService
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"[ExportService] Export failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    public static bool ExportFinanceToExcel(
+        string periodLabel,
+        ObservableCollection<FinanceEntryViewModel> income,
+        ObservableCollection<FinanceEntryViewModel> expenses,
+        ObservableCollection<BudgetViewModel> budgets,
+        ObservableCollection<CategoryBreakdownItem> breakdown,
+        decimal totalIncome, decimal totalExpenses, decimal balance,
+        string filePath)
+    {
+        try
+        {
+            using var workbook = new XLWorkbook();
+
+            // Summary sheet
+            var ws = workbook.AddWorksheet(Loc.Get("Finance"));
+            ws.Cell("A1").Value = $"{Loc.Get("Finance")} — {periodLabel}";
+            ws.Range("A1:D1").Merge().Style.Font.SetBold(true).Font.SetFontSize(14);
+
+            ws.Cell("A3").Value = Loc.Get("Income");
+            ws.Cell("B3").Value = totalIncome;
+            ws.Cell("B3").Style.NumberFormat.Format = "#,##0.00";
+            ws.Cell("A4").Value = Loc.Get("Expenses");
+            ws.Cell("B4").Value = totalExpenses;
+            ws.Cell("B4").Style.NumberFormat.Format = "#,##0.00";
+            ws.Cell("A5").Value = Loc.Get("BalanceLabel");
+            ws.Cell("B5").Value = balance;
+            ws.Cell("B5").Style.NumberFormat.Format = "#,##0.00";
+            ws.Range("A3:A5").Style.Font.SetBold(true);
+
+            // Income entries
+            var row = 7;
+            ws.Cell(row, 1).Value = Loc.Get("Income");
+            ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
+            row++;
+            ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
+            ws.Cell(row, 2).Value = Loc.Get("FinanceDescription");
+            ws.Cell(row, 3).Value = Loc.Get("Amount");
+            ws.Cell(row, 4).Value = Loc.Get("Date");
+            ws.Range(row, 1, row, 4).Style.Font.SetBold(true);
+            row++;
+
+            foreach (var e in income)
+            {
+                ws.Cell(row, 1).Value = $"{e.CategoryIcon} {e.CategoryName}";
+                ws.Cell(row, 2).Value = e.Description;
+                ws.Cell(row, 3).Value = e.Amount;
+                ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
+                ws.Cell(row, 4).Value = e.DisplayDate;
+                row++;
+            }
+
+            // Expense entries
+            row++;
+            ws.Cell(row, 1).Value = Loc.Get("Expenses");
+            ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
+            row++;
+            ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
+            ws.Cell(row, 2).Value = Loc.Get("FinanceDescription");
+            ws.Cell(row, 3).Value = Loc.Get("Amount");
+            ws.Cell(row, 4).Value = Loc.Get("Date");
+            ws.Range(row, 1, row, 4).Style.Font.SetBold(true);
+            row++;
+
+            foreach (var e in expenses)
+            {
+                ws.Cell(row, 1).Value = $"{e.CategoryIcon} {e.CategoryName}";
+                ws.Cell(row, 2).Value = e.Description;
+                ws.Cell(row, 3).Value = e.Amount;
+                ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
+                ws.Cell(row, 4).Value = e.DisplayDate;
+                row++;
+            }
+
+            // Budgets
+            if (budgets.Count > 0)
+            {
+                row++;
+                ws.Cell(row, 1).Value = Loc.Get("Budget");
+                ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
+                row++;
+                ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
+                ws.Cell(row, 2).Value = Loc.Get("Budget");
+                ws.Cell(row, 3).Value = Loc.Get("Spent");
+                ws.Cell(row, 4).Value = "%";
+                ws.Range(row, 1, row, 4).Style.Font.SetBold(true);
+                row++;
+
+                foreach (var b in budgets)
+                {
+                    ws.Cell(row, 1).Value = $"{b.CategoryIcon} {b.CategoryName}";
+                    ws.Cell(row, 2).Value = b.Amount;
+                    ws.Cell(row, 2).Style.NumberFormat.Format = "#,##0.00";
+                    ws.Cell(row, 3).Value = b.SpentAmount;
+                    ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
+                    ws.Cell(row, 4).Value = b.ProgressPercent / 100;
+                    ws.Cell(row, 4).Style.NumberFormat.Format = "0%";
+                    row++;
+                }
+            }
+
+            // Category breakdown
+            if (breakdown.Count > 0)
+            {
+                row++;
+                ws.Cell(row, 1).Value = Loc.Get("FinCategories");
+                ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
+                row++;
+
+                foreach (var c in breakdown)
+                {
+                    ws.Cell(row, 1).Value = $"{c.Icon} {c.Name}";
+                    ws.Cell(row, 2).Value = c.Amount;
+                    ws.Cell(row, 2).Style.NumberFormat.Format = "#,##0.00";
+                    row++;
+                }
+            }
+
+            ws.Columns().AdjustToContents();
+            workbook.SaveAs(filePath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[ExportService] Finance export failed: {ex.Message}");
             return false;
         }
     }

--- a/DailyPlanner/Services/Loc.cs
+++ b/DailyPlanner/Services/Loc.cs
@@ -445,6 +445,15 @@ public sealed class Loc : INotifyPropertyChanged
             ["Paid"] = "Оплачено",
             ["Pending"] = "Ожидает",
             ["FinanceDescription"] = "Описание",
+            ["Savings"] = "Накопления",
+            ["SavingsRate"] = "Норма сбережений",
+            ["Analytics"] = "Аналитика",
+            ["FinCategories"] = "По категориям",
+            ["MonthlyTrend"] = "Тренд по месяцам",
+            ["ExportFinance"] = "Экспорт финансов",
+            ["AnnualTotal"] = "В год",
+            ["NextPayment"] = "Следующий платёж",
+            ["Date"] = "Дата",
         },
 
         ["en"] = new()
@@ -749,6 +758,15 @@ public sealed class Loc : INotifyPropertyChanged
             ["Paid"] = "Paid",
             ["Pending"] = "Pending",
             ["FinanceDescription"] = "Description",
+            ["Savings"] = "Savings",
+            ["SavingsRate"] = "Savings rate",
+            ["Analytics"] = "Analytics",
+            ["FinCategories"] = "By category",
+            ["MonthlyTrend"] = "Monthly trend",
+            ["ExportFinance"] = "Export finance",
+            ["AnnualTotal"] = "Per year",
+            ["NextPayment"] = "Next payment",
+            ["Date"] = "Date",
         },
 
         ["es"] = new()
@@ -1053,6 +1071,15 @@ public sealed class Loc : INotifyPropertyChanged
             ["Paid"] = "Pagado",
             ["Pending"] = "Pendiente",
             ["FinanceDescription"] = "Descripción",
+            ["Savings"] = "Ahorros",
+            ["SavingsRate"] = "Tasa de ahorro",
+            ["Analytics"] = "Analítica",
+            ["FinCategories"] = "Por categoría",
+            ["MonthlyTrend"] = "Tendencia mensual",
+            ["ExportFinance"] = "Exportar finanzas",
+            ["AnnualTotal"] = "Anual",
+            ["NextPayment"] = "Próximo pago",
+            ["Date"] = "Fecha",
         },
 
         ["fr"] = new()
@@ -1357,6 +1384,15 @@ public sealed class Loc : INotifyPropertyChanged
             ["Paid"] = "Payé",
             ["Pending"] = "En attente",
             ["FinanceDescription"] = "Description",
+            ["Savings"] = "Épargne",
+            ["SavingsRate"] = "Taux d'épargne",
+            ["Analytics"] = "Analytique",
+            ["FinCategories"] = "Par catégorie",
+            ["MonthlyTrend"] = "Tendance mensuelle",
+            ["ExportFinance"] = "Exporter les finances",
+            ["AnnualTotal"] = "Par an",
+            ["NextPayment"] = "Prochain paiement",
+            ["Date"] = "Date",
         },
     };
 

--- a/DailyPlanner/Services/PlannerService.cs
+++ b/DailyPlanner/Services/PlannerService.cs
@@ -790,4 +790,51 @@ public sealed class PlannerService
 
         return [.. starts.Distinct().OrderBy(d => d)];
     }
+
+    // ─── Finance: Analytics ─────────────────────────────────────────
+
+    public async Task<List<CategoryBreakdownItem>> GetExpensesByCategoryAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
+    {
+        await using var db = PlannerDbContextFactory.Create();
+        return await db.FinanceEntries
+            .Where(e => e.Type == FinanceEntryType.Expense && e.Date >= from && e.Date <= to)
+            .GroupBy(e => new { e.CategoryId, e.Category!.Name, e.Category.Icon, e.Category.Color })
+            .Select(g => new CategoryBreakdownItem(
+                g.Key.CategoryId, g.Key.Name, g.Key.Icon, g.Key.Color, g.Sum(e => e.Amount)))
+            .OrderByDescending(x => x.Amount)
+            .ToListAsync(ct);
+    }
+
+    public async Task<List<MonthlyFinanceSummary>> GetMonthlyTotalsAsync(int months, CancellationToken ct = default)
+    {
+        await using var db = PlannerDbContextFactory.Create();
+        var cutoff = DateOnly.FromDateTime(DateTime.Today).AddMonths(-months + 1);
+        cutoff = new DateOnly(cutoff.Year, cutoff.Month, 1);
+
+        var entries = await db.FinanceEntries
+            .Where(e => e.Date >= cutoff)
+            .GroupBy(e => new { e.Date.Year, e.Date.Month, e.Type })
+            .Select(g => new { g.Key.Year, g.Key.Month, g.Key.Type, Total = g.Sum(e => e.Amount) })
+            .ToListAsync(ct);
+
+        var result = new List<MonthlyFinanceSummary>();
+        for (var i = 0; i < months; i++)
+        {
+            var d = DateOnly.FromDateTime(DateTime.Today).AddMonths(-months + 1 + i);
+            var y = d.Year;
+            var m = d.Month;
+            var inc = entries.FirstOrDefault(e => e.Year == y && e.Month == m && e.Type == FinanceEntryType.Income)?.Total ?? 0;
+            var exp = entries.FirstOrDefault(e => e.Year == y && e.Month == m && e.Type == FinanceEntryType.Expense)?.Total ?? 0;
+            result.Add(new MonthlyFinanceSummary(y, m, inc, exp));
+        }
+
+        return result;
+    }
+}
+
+public sealed record CategoryBreakdownItem(int CategoryId, string Name, string Icon, string Color, decimal Amount);
+public sealed record MonthlyFinanceSummary(int Year, int Month, decimal Income, decimal Expenses)
+{
+    public decimal Balance => Income - Expenses;
+    public string Label => $"{Loc.GetMonthName(Month)[..3]} {Year % 100:D2}";
 }

--- a/DailyPlanner/ViewModels/BudgetViewModel.cs
+++ b/DailyPlanner/ViewModels/BudgetViewModel.cs
@@ -29,6 +29,13 @@ public sealed partial class BudgetViewModel : ObservableObject
 
     public bool IsOverBudget => SpentAmount > Amount;
     public bool IsWarning => ProgressPercent >= 80 && !IsOverBudget;
+    public string RemainingText => IsOverBudget
+        ? $"{Loc.Get("OverBudget")}: {SpentAmount - Amount:N2}"
+        : $"{Loc.Get("Remaining")}: {RemainingAmount:N2}";
+    public bool ShowWarning => IsOverBudget || IsWarning;
+    public string WarningText => IsOverBudget
+        ? Loc.Get("OverBudget")
+        : IsWarning ? $"{ProgressPercent:N0}% {Loc.Get("Spent").ToLowerInvariant()}" : string.Empty;
 
     partial void OnAmountChanged(decimal value)
     {
@@ -38,6 +45,9 @@ public sealed partial class BudgetViewModel : ObservableObject
         OnPropertyChanged(nameof(ProgressPercent));
         OnPropertyChanged(nameof(IsOverBudget));
         OnPropertyChanged(nameof(IsWarning));
+        OnPropertyChanged(nameof(RemainingText));
+        OnPropertyChanged(nameof(ShowWarning));
+        OnPropertyChanged(nameof(WarningText));
         Save();
     }
 
@@ -47,6 +57,9 @@ public sealed partial class BudgetViewModel : ObservableObject
         OnPropertyChanged(nameof(ProgressPercent));
         OnPropertyChanged(nameof(IsOverBudget));
         OnPropertyChanged(nameof(IsWarning));
+        OnPropertyChanged(nameof(RemainingText));
+        OnPropertyChanged(nameof(ShowWarning));
+        OnPropertyChanged(nameof(WarningText));
     }
 
     private void Save()

--- a/DailyPlanner/ViewModels/FinanceViewModel.cs
+++ b/DailyPlanner/ViewModels/FinanceViewModel.cs
@@ -23,6 +23,9 @@ public sealed partial class FinanceViewModel : ObservableObject
     [ObservableProperty] private decimal _debtOwedToMe;
     [ObservableProperty] private decimal _debtIOwn;
     [ObservableProperty] private decimal _monthlyObligatory;
+    [ObservableProperty] private decimal _savings;
+    [ObservableProperty] private string _savingsTrendArrow = string.Empty;
+    [ObservableProperty] private double _savingsRatePercent;
 
     public ObservableCollection<FinanceEntryViewModel> IncomeEntries { get; } = [];
     public ObservableCollection<FinanceEntryViewModel> ExpenseEntries { get; } = [];
@@ -32,6 +35,8 @@ public sealed partial class FinanceViewModel : ObservableObject
     public ObservableCollection<DebtViewModel> LentDebts { get; } = [];
     public ObservableCollection<DebtViewModel> BorrowedDebts { get; } = [];
     public ObservableCollection<RecurringPaymentViewModel> RecurringPayments { get; } = [];
+    public ObservableCollection<CategoryBreakdownItem> CategoryBreakdown { get; } = [];
+    public ObservableCollection<MonthlyFinanceSummary> MonthlyTrend { get; } = [];
 
     public FinanceViewModel(PlannerService service)
     {
@@ -141,6 +146,34 @@ public sealed partial class FinanceViewModel : ObservableObject
                 };
         }
         MonthlyObligatory = Math.Round(obligatory, 2);
+
+        // Savings
+        Savings = income - expenses;
+        SavingsRatePercent = income > 0 ? Math.Round((double)(Savings / income) * 100, 1) : 0;
+
+        // Analytics: category breakdown
+        var breakdown = await _service.GetExpensesByCategoryAsync(firstDay, lastDay);
+        CategoryBreakdown.Clear();
+        foreach (var item in breakdown)
+            CategoryBreakdown.Add(item);
+
+        // Analytics: 6-month trend
+        var trend = await _service.GetMonthlyTotalsAsync(6);
+        MonthlyTrend.Clear();
+        foreach (var item in trend)
+            MonthlyTrend.Add(item);
+
+        // Savings trend arrow (compare to previous month)
+        if (trend.Count >= 2)
+        {
+            var prev = trend[^2].Balance;
+            SavingsTrendArrow = Savings > prev ? "↑" : Savings < prev ? "↓" : "→";
+        }
+        else
+        {
+            SavingsTrendArrow = string.Empty;
+        }
+
         IsLoading = false;
         _isLoadingData = false;
     }
@@ -334,5 +367,30 @@ public sealed partial class FinanceViewModel : ObservableObject
         if (SelectedMonth == 12) { SelectedMonth = 1; SelectedYear++; }
         else SelectedMonth++;
         await LoadDataAsync();
+    }
+
+    [RelayCommand]
+    private void ExportFinance()
+    {
+        var dialog = new Microsoft.Win32.SaveFileDialog
+        {
+            FileName = $"Finance_{SelectedYear}-{SelectedMonth:D2}",
+            DefaultExt = ".xlsx",
+            Filter = "Excel (.xlsx)|*.xlsx"
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            var firstDay = new DateOnly(SelectedYear, SelectedMonth, 1);
+            var lastDay = firstDay.AddMonths(1).AddDays(-1);
+            var success = ExportService.ExportFinanceToExcel(
+                PeriodLabel, IncomeEntries, ExpenseEntries, Budgets,
+                CategoryBreakdown, TotalIncome, TotalExpenses, Balance, dialog.FileName);
+
+            if (success)
+                System.Windows.MessageBox.Show(Loc.Get("ExportSuccess"), Loc.Get("ExportTitle"));
+            else
+                System.Windows.MessageBox.Show(Loc.Get("ExportError"), Loc.Get("ExportTitle"));
+        }
     }
 }

--- a/DailyPlanner/ViewModels/RecurringPaymentViewModel.cs
+++ b/DailyPlanner/ViewModels/RecurringPaymentViewModel.cs
@@ -65,12 +65,47 @@ public sealed partial class RecurringPaymentViewModel : ObservableObject
     public bool HasEndDate => _model.EndDate is not null;
     public string EndDateLabel => _model.EndDate?.ToString("dd.MM.yyyy") ?? string.Empty;
 
+    public decimal AnnualTotal => Frequency switch
+    {
+        PaymentFrequency.Monthly => Amount * 12,
+        PaymentFrequency.Weekly => Amount * 52,
+        PaymentFrequency.Biweekly => Amount * 26,
+        PaymentFrequency.Quarterly => Amount * 4,
+        PaymentFrequency.Yearly => Amount,
+        _ => 0
+    };
+
+    public string NextPaymentDate
+    {
+        get
+        {
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            if (!IsActive) return string.Empty;
+            if (_model.EndDate is not null && _model.EndDate < today) return string.Empty;
+
+            return Frequency switch
+            {
+                PaymentFrequency.Monthly when DayOfMonth is not null =>
+                    (today.Day <= DayOfMonth
+                        ? new DateOnly(today.Year, today.Month, Math.Min(DayOfMonth.Value, DateTime.DaysInMonth(today.Year, today.Month)))
+                        : new DateOnly(today.Year, today.Month, 1).AddMonths(1)
+                            .AddDays(Math.Min(DayOfMonth.Value, DateTime.DaysInMonth(today.AddMonths(1).Year, today.AddMonths(1).Month)) - 1))
+                    .ToString("dd.MM.yyyy"),
+                PaymentFrequency.Weekly when _model.DayOfWeek is not null =>
+                    Enumerable.Range(0, 7).Select(i => today.AddDays(i))
+                        .First(d => d.DayOfWeek == _model.DayOfWeek).ToString("dd.MM.yyyy"),
+                _ => string.Empty
+            };
+        }
+    }
+
     partial void OnNameChanged(string value) { _model.Name = value; Save(); }
     partial void OnAmountChanged(decimal value)
     {
         if (value < 0) { Amount = 0; return; }
         _model.Amount = value;
         OnPropertyChanged(nameof(DisplayAmount));
+        OnPropertyChanged(nameof(AnnualTotal));
         Save();
     }
     partial void OnFrequencyChanged(PaymentFrequency value) { _model.Frequency = value; OnPropertyChanged(nameof(FrequencyLabel)); OnPropertyChanged(nameof(ScheduleLabel)); Save(); }

--- a/DailyPlanner/Views/FinancePage.xaml
+++ b/DailyPlanner/Views/FinancePage.xaml
@@ -72,7 +72,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel Margin="24,0,24,24" MaxWidth="960" HorizontalAlignment="Left">
 
-            <!-- Header with month navigation -->
+            <!-- Header with month navigation + export -->
             <DockPanel Margin="0,0,0,20">
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                     <ui:Button Icon="{ui:SymbolIcon ChevronLeft24}" Appearance="Transparent"
@@ -83,26 +83,32 @@
                     <ui:Button Icon="{ui:SymbolIcon ChevronRight24}" Appearance="Transparent"
                                Command="{Binding NextMonthCommand}" Padding="8"/>
                 </StackPanel>
+                <ui:Button Content="{Binding [ExportFinance], Source={x:Static svc:Loc.Instance}}"
+                           Icon="{ui:SymbolIcon ArrowDownload24}" Appearance="Transparent"
+                           Command="{Binding ExportFinanceCommand}"
+                           HorizontalAlignment="Right" DockPanel.Dock="Right"/>
             </DockPanel>
 
-            <!-- Summary Cards -->
+            <!-- Summary Cards (5 cards) -->
             <Grid Margin="0,0,0,20">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="10"/>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="10"/>
                     <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="12"/>
+                    <ColumnDefinition Width="10"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="10"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
                 <!-- Income -->
-                <Border Grid.Column="0" Style="{StaticResource PlannerCard}" Padding="16">
+                <Border Grid.Column="0" Style="{StaticResource PlannerCard}" Padding="14">
                     <StackPanel>
                         <TextBlock Text="{Binding [Income], Source={x:Static svc:Loc.Instance}}"
                                    Style="{StaticResource StatLabel}"/>
-                        <TextBlock FontSize="28" FontWeight="Bold"
+                        <TextBlock FontSize="24" FontWeight="Bold"
                                    Foreground="{DynamicResource SuccessBrush}">
                             <Run Text="+"/><Run Text="{Binding TotalIncome, StringFormat=N2, Mode=OneWay}"/>
                         </TextBlock>
@@ -110,11 +116,11 @@
                 </Border>
 
                 <!-- Expenses -->
-                <Border Grid.Column="2" Style="{StaticResource PlannerCard}" Padding="16">
+                <Border Grid.Column="2" Style="{StaticResource PlannerCard}" Padding="14">
                     <StackPanel>
                         <TextBlock Text="{Binding [Expenses], Source={x:Static svc:Loc.Instance}}"
                                    Style="{StaticResource StatLabel}"/>
-                        <TextBlock FontSize="28" FontWeight="Bold"
+                        <TextBlock FontSize="24" FontWeight="Bold"
                                    Foreground="{DynamicResource DangerBrush}">
                             <Run Text="-"/><Run Text="{Binding TotalExpenses, StringFormat=N2, Mode=OneWay}"/>
                         </TextBlock>
@@ -122,27 +128,43 @@
                 </Border>
 
                 <!-- Balance -->
-                <Border Grid.Column="4" Style="{StaticResource PlannerCard}" Padding="16">
+                <Border Grid.Column="4" Style="{StaticResource PlannerCard}" Padding="14">
                     <StackPanel>
                         <TextBlock Text="{Binding [BalanceLabel], Source={x:Static svc:Loc.Instance}}"
                                    Style="{StaticResource StatLabel}"/>
-                        <TextBlock Text="{Binding Balance, StringFormat=N2}" FontSize="28" FontWeight="Bold"
+                        <TextBlock Text="{Binding Balance, StringFormat=N2}" FontSize="24" FontWeight="Bold"
                                    Foreground="{DynamicResource AccentBrush}"/>
                     </StackPanel>
                 </Border>
 
+                <!-- Savings -->
+                <Border Grid.Column="6" Style="{StaticResource PlannerCard}" Padding="14">
+                    <StackPanel>
+                        <TextBlock Style="{StaticResource StatLabel}">
+                            <Run Text="{Binding [Savings], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
+                            <Run Text="{Binding SavingsTrendArrow, Mode=OneWay}" FontWeight="Bold"/>
+                        </TextBlock>
+                        <TextBlock Text="{Binding Savings, StringFormat=N2}" FontSize="24" FontWeight="Bold"
+                                   Foreground="{DynamicResource InfoBrush}"/>
+                        <TextBlock FontSize="10" Foreground="{DynamicResource MutedBrush}">
+                            <Run Text="{Binding SavingsRatePercent, StringFormat=N1, Mode=OneWay}"/>
+                            <Run Text="%"/>
+                        </TextBlock>
+                    </StackPanel>
+                </Border>
+
                 <!-- Obligatory -->
-                <Border Grid.Column="6" Style="{StaticResource PlannerCard}" Padding="16">
+                <Border Grid.Column="8" Style="{StaticResource PlannerCard}" Padding="14">
                     <StackPanel>
                         <TextBlock Text="{Binding [MonthlyObligatory], Source={x:Static svc:Loc.Instance}}"
                                    Style="{StaticResource StatLabel}"/>
-                        <TextBlock Text="{Binding MonthlyObligatory, StringFormat=N2}" FontSize="28" FontWeight="Bold"
+                        <TextBlock Text="{Binding MonthlyObligatory, StringFormat=N2}" FontSize="24" FontWeight="Bold"
                                    Foreground="{DynamicResource WarningBrush}"/>
                     </StackPanel>
                 </Border>
             </Grid>
 
-            <!-- Tab Strip -->
+            <!-- Tab Strip (5 tabs) -->
             <Border Style="{StaticResource PlannerCard}" Padding="4" Margin="0,0,0,20">
                 <StackPanel Orientation="Horizontal">
                     <RadioButton Content="{Binding [Income], Source={x:Static svc:Loc.Instance}}"
@@ -165,10 +187,15 @@
                                  IsChecked="{Binding SelectedTabIndex, Converter={conv:IntEqualConverter}, ConverterParameter=3}"
                                  GroupName="FinanceTab"
                                  Checked="TabChanged" Tag="3"/>
+                    <RadioButton Content="{Binding [Analytics], Source={x:Static svc:Loc.Instance}}"
+                                 Style="{StaticResource FinanceTabButton}"
+                                 IsChecked="{Binding SelectedTabIndex, Converter={conv:IntEqualConverter}, ConverterParameter=4}"
+                                 GroupName="FinanceTab"
+                                 Checked="TabChanged" Tag="4"/>
                 </StackPanel>
             </Border>
 
-            <!-- TAB CONTENT: Income (index 0) -->
+            <!-- ═══════════════ TAB 0: Income ═══════════════ -->
             <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=0}">
                 <Border Style="{StaticResource PlannerCard}" Padding="20">
                     <StackPanel>
@@ -191,18 +218,25 @@
                                                        DockPanel.Dock="Right" Padding="4" VerticalAlignment="Center"
                                                        Command="{Binding DataContext.RemoveIncomeEntryCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                        CommandParameter="{Binding}"/>
-                                            <TextBlock DockPanel.Dock="Right" FontSize="20" FontWeight="Bold"
-                                                       Foreground="{DynamicResource SuccessBrush}" VerticalAlignment="Center" Margin="12,0">
-                                                <Run Text="+"/><Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
-                                            </TextBlock>
+                                            <TextBox DockPanel.Dock="Right"
+                                                     Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                     Style="{StaticResource FinanceAmountTextBox}"
+                                                     Foreground="{DynamicResource SuccessBrush}"
+                                                     VerticalAlignment="Center" Margin="8,0"/>
                                             <StackPanel VerticalAlignment="Center">
                                                 <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                                                          Style="{StaticResource FinanceInlineTextBox}"/>
-                                                <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" Margin="4,2,0,0">
-                                                    <Run Text="{Binding CategoryName, Mode=OneWay}"/>
-                                                    <Run Text=" · "/>
-                                                    <Run Text="{Binding DisplayDate, Mode=OneWay}"/>
-                                                </TextBlock>
+                                                <StackPanel Orientation="Horizontal" Margin="4,2,0,0">
+                                                    <ComboBox ItemsSource="{Binding DataContext.IncomeCategories, RelativeSource={RelativeSource AncestorType=Page}}"
+                                                              SelectedValue="{Binding CategoryId}"
+                                                              SelectedValuePath="Id"
+                                                              DisplayMemberPath="Name"
+                                                              FontSize="11" Padding="4,1" MinWidth="100"
+                                                              Background="Transparent" BorderThickness="0"/>
+                                                    <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                        <Run Text="{Binding DisplayDate, Mode=OneWay}"/>
+                                                    </TextBlock>
+                                                </StackPanel>
                                             </StackPanel>
                                         </DockPanel>
                                     </Border>
@@ -210,7 +244,6 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
 
-                        <!-- Empty state -->
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,16"
@@ -223,7 +256,7 @@
                 </Border>
             </StackPanel>
 
-            <!-- TAB CONTENT: Expenses (index 1) -->
+            <!-- ═══════════════ TAB 1: Expenses ═══════════════ -->
             <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=1}">
                 <!-- Expenses section -->
                 <Border Style="{StaticResource PlannerCard}" Padding="20" Margin="0,0,0,16">
@@ -247,18 +280,25 @@
                                                        DockPanel.Dock="Right" Padding="4" VerticalAlignment="Center"
                                                        Command="{Binding DataContext.RemoveExpenseEntryCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                        CommandParameter="{Binding}"/>
-                                            <TextBlock DockPanel.Dock="Right" FontSize="20" FontWeight="Bold"
-                                                       Foreground="{DynamicResource DangerBrush}" VerticalAlignment="Center" Margin="12,0">
-                                                <Run Text="-"/><Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
-                                            </TextBlock>
+                                            <TextBox DockPanel.Dock="Right"
+                                                     Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                     Style="{StaticResource FinanceAmountTextBox}"
+                                                     Foreground="{DynamicResource DangerBrush}"
+                                                     VerticalAlignment="Center" Margin="8,0"/>
                                             <StackPanel VerticalAlignment="Center">
                                                 <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                                                          Style="{StaticResource FinanceInlineTextBox}"/>
-                                                <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" Margin="4,2,0,0">
-                                                    <Run Text="{Binding CategoryName, Mode=OneWay}"/>
-                                                    <Run Text=" · "/>
-                                                    <Run Text="{Binding DisplayDate, Mode=OneWay}"/>
-                                                </TextBlock>
+                                                <StackPanel Orientation="Horizontal" Margin="4,2,0,0">
+                                                    <ComboBox ItemsSource="{Binding DataContext.ExpenseCategories, RelativeSource={RelativeSource AncestorType=Page}}"
+                                                              SelectedValue="{Binding CategoryId}"
+                                                              SelectedValuePath="Id"
+                                                              DisplayMemberPath="Name"
+                                                              FontSize="11" Padding="4,1" MinWidth="100"
+                                                              Background="Transparent" BorderThickness="0"/>
+                                                    <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" VerticalAlignment="Center" Margin="8,0,0,0">
+                                                        <Run Text="{Binding DisplayDate, Mode=OneWay}"/>
+                                                    </TextBlock>
+                                                </StackPanel>
                                             </StackPanel>
                                         </DockPanel>
                                     </Border>
@@ -266,7 +306,6 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
 
-                        <!-- Empty state -->
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,16"
@@ -315,6 +354,10 @@
                                                          Height="4" Margin="0,8,0,0"
                                                          Foreground="{Binding ProgressPercent, Converter={StaticResource BudgetBrushConv}}"
                                                          Style="{StaticResource BudgetProgressBar}"/>
+                                            <!-- Budget warning -->
+                                            <TextBlock Text="{Binding WarningText}" FontSize="11" FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource WarningBrush}" Margin="0,4,0,0"
+                                                       Visibility="{Binding ShowWarning, Converter={StaticResource VisConv}}"/>
                                         </StackPanel>
                                     </Border>
                                 </DataTemplate>
@@ -333,7 +376,7 @@
                 </Border>
             </StackPanel>
 
-            <!-- TAB CONTENT: Debts (index 2) -->
+            <!-- ═══════════════ TAB 2: Debts ═══════════════ -->
             <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=2}">
 
                 <!-- Debt summary cards -->
@@ -502,7 +545,7 @@
                 </Border>
             </StackPanel>
 
-            <!-- TAB CONTENT: Recurring Payments (index 3) -->
+            <!-- ═══════════════ TAB 3: Recurring Payments ═══════════════ -->
             <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=3}">
                 <Border Style="{StaticResource PlannerCard}" Padding="20">
                     <StackPanel>
@@ -543,6 +586,17 @@
                                                     <Run Text=" · "/>
                                                     <Run Text="{Binding CategoryName, Mode=OneWay}"/>
                                                 </TextBlock>
+                                                <!-- Next payment + annual total -->
+                                                <StackPanel Orientation="Horizontal" Margin="4,2,0,0">
+                                                    <TextBlock FontSize="10" Foreground="{DynamicResource InfoBrush}"
+                                                               Text="{Binding NextPaymentDate, Mode=OneWay}"
+                                                               Margin="0,0,12,0"/>
+                                                    <TextBlock FontSize="10" Foreground="{DynamicResource MutedBrush}">
+                                                        <Run Text="{Binding [AnnualTotal], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
+                                                        <Run Text=": "/>
+                                                        <Run Text="{Binding AnnualTotal, StringFormat=N0, Mode=OneWay}"/>
+                                                    </TextBlock>
+                                                </StackPanel>
                                                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                                     <Border Background="{DynamicResource SubtleBgBrush}" CornerRadius="6" Padding="8,3" Margin="0,0,8,0">
                                                         <StackPanel Orientation="Horizontal">
@@ -580,6 +634,146 @@
                                        Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
                                        Command="{Binding AddRecurringPaymentCommand}" CommandParameter="Income"/>
                         </StackPanel>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+
+            <!-- ═══════════════ TAB 4: Analytics ═══════════════ -->
+            <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=4}">
+
+                <!-- Category Breakdown (horizontal bars) -->
+                <Border Style="{StaticResource PlannerCard}" Padding="20" Margin="0,0,0,16">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,14">
+                            <ui:SymbolIcon Symbol="DataPie24" FontSize="18"
+                                           Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding [FinCategories], Source={x:Static svc:Loc.Instance}}"
+                                       FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+
+                        <ItemsControl ItemsSource="{Binding CategoryBreakdown}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="0,0,0,10">
+                                        <DockPanel Margin="0,0,0,4">
+                                            <TextBlock FontSize="13" VerticalAlignment="Center">
+                                                <Run Text="{Binding Icon, Mode=OneWay}"/>
+                                                <Run Text=" "/>
+                                                <Run Text="{Binding Name, Mode=OneWay}"/>
+                                            </TextBlock>
+                                            <TextBlock DockPanel.Dock="Right" FontSize="13" FontWeight="SemiBold"
+                                                       HorizontalAlignment="Right" VerticalAlignment="Center"
+                                                       Foreground="{DynamicResource DangerBrush}">
+                                                <Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
+                                            </TextBlock>
+                                        </DockPanel>
+                                        <Border Background="{DynamicResource ProgressTrackBrush}" CornerRadius="3" Height="8">
+                                            <Border CornerRadius="3" HorizontalAlignment="Left"
+                                                    Height="8" MinWidth="4">
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Background">
+                                                            <Setter.Value>
+                                                                <SolidColorBrush Color="{Binding Color, FallbackValue=#cba6f7}"/>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </Style>
+                                                </Border.Style>
+                                                <Border.Width>
+                                                    <MultiBinding Converter="{conv:CategoryBarWidthConverter}">
+                                                        <Binding Path="Amount"/>
+                                                        <Binding Path="DataContext.TotalExpenses"
+                                                                 RelativeSource="{RelativeSource AncestorType=Page}"/>
+                                                    </MultiBinding>
+                                                </Border.Width>
+                                            </Border>
+                                        </Border>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
+                                   FontSize="12" Foreground="{DynamicResource MutedBrush}"
+                                   HorizontalAlignment="Center" Margin="0,12"
+                                   Visibility="{Binding CategoryBreakdown.Count, Converter={StaticResource InvVisConv}}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- 6-Month Income/Expense Trend (bar chart) -->
+                <Border Style="{StaticResource PlannerCard}" Padding="20" Margin="0,0,0,16">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,14">
+                            <ui:SymbolIcon Symbol="ArrowTrendingLines24" FontSize="18"
+                                           Foreground="{DynamicResource InfoBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding [MonthlyTrend], Source={x:Static svc:Loc.Instance}}"
+                                       FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+
+                        <ItemsControl ItemsSource="{Binding MonthlyTrend}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <UniformGrid Columns="{Binding MonthlyTrend.Count}" Rows="1"/>
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Margin="4,0">
+                                        <!-- Income bar -->
+                                        <Border Background="{DynamicResource SuccessBrush}" CornerRadius="4,4,0,0"
+                                                Height="{Binding Income, Converter={conv:TrendBarHeightConverter}}"
+                                                VerticalAlignment="Bottom" Opacity="0.7"
+                                                ToolTip="{Binding Income, StringFormat=N2}"/>
+                                        <!-- Expense bar -->
+                                        <Border Background="{DynamicResource DangerBrush}" CornerRadius="0,0,4,4"
+                                                Height="{Binding Expenses, Converter={conv:TrendBarHeightConverter}}"
+                                                VerticalAlignment="Top" Opacity="0.7"
+                                                ToolTip="{Binding Expenses, StringFormat=N2}"
+                                                Margin="0,2,0,0"/>
+                                        <TextBlock Text="{Binding Label}" FontSize="10"
+                                                   Foreground="{DynamicResource MutedBrush}"
+                                                   HorizontalAlignment="Center" Margin="0,6,0,0"/>
+                                        <TextBlock FontSize="10" Foreground="{DynamicResource AccentLightBrush}"
+                                                   HorizontalAlignment="Center">
+                                            <Run Text="{Binding Balance, StringFormat=N0, Mode=OneWay}"/>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
+                                   FontSize="12" Foreground="{DynamicResource MutedBrush}"
+                                   HorizontalAlignment="Center" Margin="0,12"
+                                   Visibility="{Binding MonthlyTrend.Count, Converter={StaticResource InvVisConv}}"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Savings Rate Card -->
+                <Border Style="{StaticResource PlannerCard}" Padding="20">
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <ui:SymbolIcon Symbol="DataBarVertical24" FontSize="18"
+                                           Foreground="{DynamicResource InfoBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBlock Text="{Binding [SavingsRate], Source={x:Static svc:Loc.Instance}}"
+                                       FontSize="15" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                        </StackPanel>
+                        <DockPanel>
+                            <TextBlock DockPanel.Dock="Right" FontSize="28" FontWeight="Bold"
+                                       Foreground="{DynamicResource InfoBrush}" VerticalAlignment="Center">
+                                <Run Text="{Binding SavingsRatePercent, StringFormat=N1, Mode=OneWay}"/><Run Text="%"/>
+                            </TextBlock>
+                            <ProgressBar Value="{Binding SavingsRatePercent}" Maximum="100"
+                                         Height="10" Margin="0,0,20,0"
+                                         Style="{StaticResource AccentProgressBar}"/>
+                        </DockPanel>
+                        <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" Margin="0,8,0,0">
+                            <Run Text="{Binding [Savings], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
+                            <Run Text=": "/>
+                            <Run Text="{Binding Savings, StringFormat=N2, Mode=OneWay}" FontWeight="SemiBold"/>
+                            <Run Text=" "/>
+                            <Run Text="{Binding SavingsTrendArrow, Mode=OneWay}"/>
+                        </TextBlock>
                     </StackPanel>
                 </Border>
             </StackPanel>


### PR DESCRIPTION
## Summary
- **New Analytics tab** (tab 4) with expense category breakdown bars, 6-month income/expense trend chart, and savings rate card with progress bar
- **5th summary card** — Savings with trend arrow (↑/↓) and savings rate percentage
- **UX improvements**: ComboBox category selection on entries, inline amount editing, budget warning indicators (80%+ threshold and over-budget), recurring payment next date and annual total
- **Finance Excel export** button in header — exports income, expenses, budgets, and category breakdown
- **9 new localization keys** in all 4 languages (ru/en/es/fr)
- **2 new analytics converters** (CategoryBarWidthConverter, TrendBarHeightConverter)
- **2 new PlannerService methods** (GetExpensesByCategoryAsync, GetMonthlyTotalsAsync)

## Test plan
- [ ] Open Finance page, verify 5 summary cards render correctly
- [ ] Switch to each tab (Income, Expenses, Debts, Recurring, Analytics)
- [ ] Add income/expense entries, verify ComboBox category and inline amount editing
- [ ] Check budget warnings appear at 80%+ and over-budget
- [ ] Verify Analytics tab: category bars, trend chart, savings rate
- [ ] Test Excel export button — verify .xlsx file generates correctly
- [ ] Switch languages and verify new keys display properly