### PR TITLE
Fix Finance: locale crash, dynamic states, editable debts

### DIFF
--- a/DailyPlanner/Converters/FinanceConverters.cs
+++ b/DailyPlanner/Converters/FinanceConverters.cs
@@ -63,12 +63,18 @@ public sealed class BudgetProgressToBrushConverter : IValueConverter
 public sealed class DecimalToCurrencyConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-        => value is decimal d ? $"{d:N2}" : "0.00";
+        => value is decimal d ? d.ToString("N2", CultureInfo.InvariantCulture) : "0.00";
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if (value is string s && decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
-            return result;
+        if (value is string s)
+        {
+            // Try invariant first, then current culture
+            if (decimal.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                return result;
+            if (decimal.TryParse(s, NumberStyles.Any, CultureInfo.CurrentCulture, out result))
+                return result;
+        }
         return 0m;
     }
 }
@@ -98,6 +104,29 @@ public sealed class IntEqualConverter : MarkupExtension, IValueConverter
             return p;
         return System.Windows.Data.Binding.DoNothing;
     }
+
+    public override object ProvideValue(IServiceProvider serviceProvider) => this;
+}
+
+/// <summary>Converts a color hex string to SolidColorBrush.</summary>
+public sealed class StringToBrushConverter : MarkupExtension, IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is string s && !string.IsNullOrEmpty(s))
+        {
+            try
+            {
+                var color = (Color)ColorConverter.ConvertFromString(s);
+                return new SolidColorBrush(color);
+            }
+            catch { }
+        }
+        return new SolidColorBrush(Color.FromRgb(0xcb, 0xa6, 0xf7));
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotSupportedException();
 
     public override object ProvideValue(IServiceProvider serviceProvider) => this;
 }

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>2.15.0</Version>
+    <Version>2.15.1</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Недельный планер с трекером привычек и аналитикой продуктивности</Description>
   </PropertyGroup>

--- a/DailyPlanner/ViewModels/FinanceViewModel.cs
+++ b/DailyPlanner/ViewModels/FinanceViewModel.cs
@@ -38,9 +38,32 @@ public sealed partial class FinanceViewModel : ObservableObject
     public ObservableCollection<CategoryBreakdownItem> CategoryBreakdown { get; } = [];
     public ObservableCollection<MonthlyFinanceSummary> MonthlyTrend { get; } = [];
 
+    // Empty state flags
+    public bool HasIncomeEntries => IncomeEntries.Count > 0;
+    public bool HasExpenseEntries => ExpenseEntries.Count > 0;
+    public bool HasBudgets => Budgets.Count > 0;
+    public bool HasLentDebts => LentDebts.Count > 0;
+    public bool HasBorrowedDebts => BorrowedDebts.Count > 0;
+    public bool HasRecurringPayments => RecurringPayments.Count > 0;
+    public bool HasCategoryBreakdown => CategoryBreakdown.Count > 0;
+    public bool HasMonthlyTrend => MonthlyTrend.Count > 0;
+    public int MonthlyTrendCount => MonthlyTrend.Count;
+
     public FinanceViewModel(PlannerService service)
     {
         _service = service;
+        IncomeEntries.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasIncomeEntries));
+        ExpenseEntries.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasExpenseEntries));
+        Budgets.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasBudgets));
+        LentDebts.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasLentDebts));
+        BorrowedDebts.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasBorrowedDebts));
+        RecurringPayments.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasRecurringPayments));
+        CategoryBreakdown.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasCategoryBreakdown));
+        MonthlyTrend.CollectionChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(HasMonthlyTrend));
+            OnPropertyChanged(nameof(MonthlyTrendCount));
+        };
     }
 
     private bool _isLoadingData;
@@ -149,7 +172,7 @@ public sealed partial class FinanceViewModel : ObservableObject
 
         // Savings
         Savings = income - expenses;
-        SavingsRatePercent = income > 0 ? Math.Round((double)(Savings / income) * 100, 1) : 0;
+        SavingsRatePercent = income > 0 ? Math.Max(0, Math.Round((double)(Savings / income) * 100, 1)) : 0;
 
         // Analytics: category breakdown
         var breakdown = await _service.GetExpensesByCategoryAsync(firstDay, lastDay);

--- a/DailyPlanner/Views/FinancePage.xaml
+++ b/DailyPlanner/Views/FinancePage.xaml
@@ -247,7 +247,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,16"
-                                   Visibility="{Binding IncomeEntries.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasIncomeEntries, Converter={StaticResource InvVisConv}}"/>
 
                         <ui:Button Content="{Binding [AddEntry], Source={x:Static svc:Loc.Instance}}"
                                    Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
@@ -309,7 +309,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,16"
-                                   Visibility="{Binding ExpenseEntries.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasExpenseEntries, Converter={StaticResource InvVisConv}}"/>
 
                         <ui:Button Content="{Binding [AddEntry], Source={x:Static svc:Loc.Instance}}"
                                    Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
@@ -367,7 +367,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,12"
-                                   Visibility="{Binding Budgets.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasBudgets, Converter={StaticResource InvVisConv}}"/>
 
                         <ui:Button Content="{Binding [AddBudget], Source={x:Static svc:Loc.Instance}}"
                                    Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
@@ -429,10 +429,11 @@
                                                            DockPanel.Dock="Right" Padding="4" VerticalAlignment="Top"
                                                            Command="{Binding DataContext.RemoveDebtCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                            CommandParameter="{Binding}"/>
-                                                <TextBlock DockPanel.Dock="Right" FontSize="20" FontWeight="Bold"
-                                                           Foreground="{DynamicResource SuccessBrush}" VerticalAlignment="Top" Margin="8,0">
-                                                    <Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
-                                                </TextBlock>
+                                                <TextBox DockPanel.Dock="Right"
+                                                         Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                         Style="{StaticResource FinanceAmountTextBox}"
+                                                         Foreground="{DynamicResource SuccessBrush}"
+                                                         VerticalAlignment="Top" Margin="8,0"/>
                                                 <StackPanel>
                                                     <TextBox Text="{Binding PersonName, UpdateSourceTrigger=PropertyChanged}"
                                                              Style="{StaticResource FinanceInlineTextBox}"
@@ -467,7 +468,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,8"
-                                   Visibility="{Binding LentDebts.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasLentDebts, Converter={StaticResource InvVisConv}}"/>
 
                         <ui:Button Content="{Binding [AddDebt], Source={x:Static svc:Loc.Instance}}"
                                    Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
@@ -497,10 +498,11 @@
                                                            DockPanel.Dock="Right" Padding="4" VerticalAlignment="Top"
                                                            Command="{Binding DataContext.RemoveDebtCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                            CommandParameter="{Binding}"/>
-                                                <TextBlock DockPanel.Dock="Right" FontSize="20" FontWeight="Bold"
-                                                           Foreground="{DynamicResource DangerBrush}" VerticalAlignment="Top" Margin="8,0">
-                                                    <Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
-                                                </TextBlock>
+                                                <TextBox DockPanel.Dock="Right"
+                                                         Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                         Style="{StaticResource FinanceAmountTextBox}"
+                                                         Foreground="{DynamicResource DangerBrush}"
+                                                         VerticalAlignment="Top" Margin="8,0"/>
                                                 <StackPanel>
                                                     <TextBox Text="{Binding PersonName, UpdateSourceTrigger=PropertyChanged}"
                                                              Style="{StaticResource FinanceInlineTextBox}"
@@ -535,7 +537,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,8"
-                                   Visibility="{Binding BorrowedDebts.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasBorrowedDebts, Converter={StaticResource InvVisConv}}"/>
 
                         <ui:Button Content="{Binding [AddDebt], Source={x:Static svc:Loc.Instance}}"
                                    Icon="{ui:SymbolIcon Add24}" Appearance="Transparent"
@@ -623,7 +625,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,12"
-                                   Visibility="{Binding RecurringPayments.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasRecurringPayments, Converter={StaticResource InvVisConv}}"/>
 
                         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                             <ui:Button Content="{Binding [AddRecurring], Source={x:Static svc:Loc.Instance}}"
@@ -670,15 +672,9 @@
                                         <Border Background="{DynamicResource ProgressTrackBrush}" CornerRadius="3" Height="8">
                                             <Border CornerRadius="3" HorizontalAlignment="Left"
                                                     Height="8" MinWidth="4">
-                                                <Border.Style>
-                                                    <Style TargetType="Border">
-                                                        <Setter Property="Background">
-                                                            <Setter.Value>
-                                                                <SolidColorBrush Color="{Binding Color, FallbackValue=#cba6f7}"/>
-                                                            </Setter.Value>
-                                                        </Setter>
-                                                    </Style>
-                                                </Border.Style>
+                                                <Border.Background>
+                                                    <Binding Path="Color" Converter="{conv:StringToBrushConverter}" FallbackValue="#cba6f7"/>
+                                                </Border.Background>
                                                 <Border.Width>
                                                     <MultiBinding Converter="{conv:CategoryBarWidthConverter}">
                                                         <Binding Path="Amount"/>
@@ -696,7 +692,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,12"
-                                   Visibility="{Binding CategoryBreakdown.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasCategoryBreakdown, Converter={StaticResource InvVisConv}}"/>
                     </StackPanel>
                 </Border>
 
@@ -713,7 +709,7 @@
                         <ItemsControl ItemsSource="{Binding MonthlyTrend}">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
-                                    <UniformGrid Columns="{Binding MonthlyTrend.Count}" Rows="1"/>
+                                    <UniformGrid Columns="{Binding DataContext.MonthlyTrendCount, RelativeSource={RelativeSource AncestorType=Page}}" Rows="1"/>
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
@@ -745,7 +741,7 @@
                         <TextBlock Text="{Binding [NoEntries], Source={x:Static svc:Loc.Instance}}"
                                    FontSize="12" Foreground="{DynamicResource MutedBrush}"
                                    HorizontalAlignment="Center" Margin="0,12"
-                                   Visibility="{Binding MonthlyTrend.Count, Converter={StaticResource InvVisConv}}"/>
+                                   Visibility="{Binding HasMonthlyTrend, Converter={StaticResource InvVisConv}}"/>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
## Summary
- **DecimalToCurrencyConverter**: fixed locale mismatch that silently zeroed amounts on Russian locale
- **Empty states**: now update dynamically when entries are added/removed (CollectionChanged → HasXXX properties)
- **Debt Amount**: now editable via TextBox (was stuck at 0 with no way to change)
- **UniformGrid Columns**: bound to observable `MonthlyTrendCount` property (was non-reactive `.Count`)
- **Category bar color**: replaced unreliable direct Color binding with `StringToBrushConverter`
- **SavingsRatePercent**: clamped to 0 minimum to prevent negative ProgressBar values

## Test plan
- [ ] Add/remove income entries — "No entries" appears/disappears correctly
- [ ] Add/remove expense entries — same
- [ ] Create debt, edit the Amount field — value saves correctly
- [ ] Enter amount with comma decimal separator (e.g. "1234,56") — should parse correctly
- [ ] Open Analytics tab — category bars show colored correctly
- [ ] Check monthly trend — columns count matches data
- [ ] Create month with expenses > income — savings rate shows 0%, not negative