### PR TITLE
Full project audit: critical fixes, memory leaks, CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Publish
+        run: dotnet publish DailyPlanner/DailyPlanner.csproj -c Release -r win-x64 --self-contained --no-restore -o ./publish

--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -11,6 +11,24 @@ public partial class App : Application
 {
     protected override async void OnStartup(StartupEventArgs e)
     {
+        DispatcherUnhandledException += (_, e) =>
+        {
+            System.Diagnostics.Debug.WriteLine($"[App] Unhandled: {e.Exception}");
+            try
+            {
+                var logPath = System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "DailyPlanner", "crash.log");
+                System.IO.File.AppendAllText(logPath,
+                    $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] {e.Exception}\n\n");
+            }
+            catch { }
+            System.Windows.MessageBox.Show(
+                $"An unexpected error occurred:\n{e.Exception.Message}",
+                "Daily Planner", MessageBoxButton.OK, MessageBoxImage.Error);
+            e.Handled = true;
+        };
+
         base.OnStartup(e);
 
         // Velopack: handle install/uninstall/update hooks (creates shortcuts, etc.)
@@ -100,13 +118,13 @@ public partial class App : Application
 
                     // Rotate: keep only last 5 backups
                     var old = System.IO.Directory.GetFiles(backupDir, "planner_*.db")
-                        .OrderByDescending(f => f)
+                        .OrderByDescending(f => System.IO.File.GetCreationTimeUtc(f))
                         .Skip(5);
                     foreach (var f in old)
-                        try { System.IO.File.Delete(f); } catch { }
+                        try { System.IO.File.Delete(f); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[App] Backup cleanup: {ex.Message}"); }
                 }
             }
-            catch { /* non-critical */ }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[App] Backup failed: {ex.Message}"); }
         });
 
         // Initialize DB

--- a/DailyPlanner/Converters/BoolToStrikethroughConverter.cs
+++ b/DailyPlanner/Converters/BoolToStrikethroughConverter.cs
@@ -185,7 +185,7 @@ public sealed class CategoryToTooltipConverter : IValueConverter
             DailyPlanner.Models.TaskCategory.Work => Loc.Get("CatWork"),
             DailyPlanner.Models.TaskCategory.Study => Loc.Get("CatStudy"),
             DailyPlanner.Models.TaskCategory.Personal => Loc.Get("CatPersonal"),
-            DailyPlanner.Models.TaskCategory.Health => Loc.Get("CatHealth"),
+            DailyPlanner.Models.TaskCategory.Health => Loc.Get("CatHealthTip"),
             DailyPlanner.Models.TaskCategory.Other => Loc.Get("CatOther"),
             _ => ""
         } : "";

--- a/DailyPlanner/MainWindow.xaml.cs
+++ b/DailyPlanner/MainWindow.xaml.cs
@@ -50,6 +50,7 @@ public partial class MainWindow : FluentWindow
         {
             _trayIcon?.Dispose();
             NotificationService.Stop();
+            _viewModel.Cleanup();
         };
     }
 
@@ -173,7 +174,7 @@ public partial class MainWindow : FluentWindow
                 if (saved == DateOnly.FromDateTime(DateTime.Today).ToString()) return;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[MainWindow] MyDay settings: {ex.Message}"); }
 
         if (_viewModel.SelectedWeek is null) return;
 
@@ -199,10 +200,10 @@ public partial class MainWindow : FluentWindow
                     System.IO.Directory.CreateDirectory(dir);
                     System.IO.File.WriteAllText(settingsPath, DateOnly.FromDateTime(DateTime.Today).ToString());
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[MainWindow] MyDay save: {ex.Message}"); }
             }
         }
-        catch { /* Don't crash app if dialog fails */ }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[MainWindow] MyDay dialog: {ex.Message}"); }
     }
 
     private void NavigateWithAnimation(Page page)

--- a/DailyPlanner/Services/DebounceService.cs
+++ b/DailyPlanner/Services/DebounceService.cs
@@ -26,7 +26,6 @@ public static class DebounceService
         try
         {
             await Task.Delay(delayMs, ct);
-            _pending.TryRemove(key, out _);
             await action();
         }
         catch (TaskCanceledException)
@@ -36,6 +35,10 @@ public static class DebounceService
         catch (Exception ex)
         {
             Debug.WriteLine($"[DebounceService] Error in '{key}': {ex.Message}");
+        }
+        finally
+        {
+            _pending.TryRemove(key, out _);
         }
     }
 }

--- a/DailyPlanner/Services/Loc.cs
+++ b/DailyPlanner/Services/Loc.cs
@@ -42,6 +42,7 @@ public sealed class Loc : INotifyPropertyChanged
         // Fallback to Russian
         if (Translations.TryGetValue("ru", out var ruDict) && ruDict.TryGetValue(key, out var ruVal))
             return ruVal;
+        System.Diagnostics.Debug.WriteLine($"[Loc] Missing key: {key}");
         return key;
     }
 
@@ -73,7 +74,7 @@ public sealed class Loc : INotifyPropertyChanged
                 if (SupportedLanguages.Contains(lang)) return lang;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[Loc] LoadSaved failed: {ex.Message}"); }
         return "ru";
     }
 
@@ -85,7 +86,7 @@ public sealed class Loc : INotifyPropertyChanged
             Directory.CreateDirectory(dir);
             File.WriteAllText(SettingsPath, Instance._lang);
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[Loc] Save failed: {ex.Message}"); }
     }
 
     // ─── All translations ────────────────────────────────────────────
@@ -208,7 +209,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["CatWork"] = "Работа (клик — сменить)",
             ["CatStudy"] = "Учёба (клик — сменить)",
             ["CatPersonal"] = "Личное (клик — сменить)",
-            ["CatHealth"] = "Здоровье (клик — сменить)",
+            ["CatHealthTip"] = "Здоровье (клик — сменить)",
             ["CatOther"] = "Другое (клик — сменить)",
 
             // Settings
@@ -424,7 +425,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DebtLent"] = "Мне должны",
             ["DebtBorrowed"] = "Я должен",
             ["DebtSettled"] = "Погашен",
-            ["Remaining"] = "Остаток",
+            ["FinRemaining"] = "Остаток",
             ["Budget"] = "Бюджет",
             ["Spent"] = "Потрачено",
             ["OverBudget"] = "Превышен",
@@ -436,7 +437,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DayOfMonthSuffix"] = "е число",
             ["NoEntries"] = "Нет записей",
             ["NoDebts"] = "Нет долгов",
-            ["Overdue"] = "Просрочен",
+            ["FinOverdue"] = "Просрочен",
             ["Active"] = "Актив.",
             ["Auto"] = "Авто",
             ["Remind"] = "Напом.",
@@ -557,7 +558,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["PriorityNone"] = "No priority",
 
             ["CatWork"] = "Work (click to change)", ["CatStudy"] = "Study (click to change)",
-            ["CatPersonal"] = "Personal (click to change)", ["CatHealth"] = "Health (click to change)",
+            ["CatPersonal"] = "Personal (click to change)", ["CatHealthTip"] = "Health (click to change)",
             ["CatOther"] = "Other (click to change)",
 
             ["SettingsTitle"] = "Settings",
@@ -752,7 +753,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DebtLent"] = "Owed to me",
             ["DebtBorrowed"] = "I owe",
             ["DebtSettled"] = "Settled",
-            ["Remaining"] = "Remaining",
+            ["FinRemaining"] = "Remaining",
             ["Budget"] = "Budget",
             ["Spent"] = "Spent",
             ["OverBudget"] = "Over budget",
@@ -764,7 +765,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DayOfMonthSuffix"] = "th",
             ["NoEntries"] = "No entries",
             ["NoDebts"] = "No debts",
-            ["Overdue"] = "Overdue",
+            ["FinOverdue"] = "Overdue",
             ["Active"] = "Active",
             ["Auto"] = "Auto",
             ["Remind"] = "Remind",
@@ -885,7 +886,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["PriorityNone"] = "Sin prioridad",
 
             ["CatWork"] = "Trabajo (clic para cambiar)", ["CatStudy"] = "Estudio (clic para cambiar)",
-            ["CatPersonal"] = "Personal (clic para cambiar)", ["CatHealth"] = "Salud (clic para cambiar)",
+            ["CatPersonal"] = "Personal (clic para cambiar)", ["CatHealthTip"] = "Salud (clic para cambiar)",
             ["CatOther"] = "Otro (clic para cambiar)",
 
             ["SettingsTitle"] = "Configuración",
@@ -1080,7 +1081,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DebtLent"] = "Me deben",
             ["DebtBorrowed"] = "Yo debo",
             ["DebtSettled"] = "Saldado",
-            ["Remaining"] = "Restante",
+            ["FinRemaining"] = "Restante",
             ["Budget"] = "Presupuesto",
             ["Spent"] = "Gastado",
             ["OverBudget"] = "Excedido",
@@ -1092,7 +1093,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DayOfMonthSuffix"] = "o",
             ["NoEntries"] = "Sin registros",
             ["NoDebts"] = "Sin deudas",
-            ["Overdue"] = "Vencido",
+            ["FinOverdue"] = "Vencido",
             ["Active"] = "Activo",
             ["Auto"] = "Auto",
             ["Remind"] = "Recordar",
@@ -1213,7 +1214,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["PriorityNone"] = "Sans priorité",
 
             ["CatWork"] = "Travail (clic pour changer)", ["CatStudy"] = "Études (clic pour changer)",
-            ["CatPersonal"] = "Personnel (clic pour changer)", ["CatHealth"] = "Santé (clic pour changer)",
+            ["CatPersonal"] = "Personnel (clic pour changer)", ["CatHealthTip"] = "Santé (clic pour changer)",
             ["CatOther"] = "Autre (clic pour changer)",
 
             ["SettingsTitle"] = "Paramètres",
@@ -1408,7 +1409,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DebtLent"] = "On me doit",
             ["DebtBorrowed"] = "Je dois",
             ["DebtSettled"] = "Réglé",
-            ["Remaining"] = "Restant",
+            ["FinRemaining"] = "Restant",
             ["Budget"] = "Budget",
             ["Spent"] = "Dépensé",
             ["OverBudget"] = "Dépassé",
@@ -1420,7 +1421,7 @@ public sealed class Loc : INotifyPropertyChanged
             ["DayOfMonthSuffix"] = "e",
             ["NoEntries"] = "Aucune entrée",
             ["NoDebts"] = "Aucune dette",
-            ["Overdue"] = "En retard",
+            ["FinOverdue"] = "En retard",
             ["Active"] = "Actif",
             ["Auto"] = "Auto",
             ["Remind"] = "Rappel",

--- a/DailyPlanner/Services/NotificationService.cs
+++ b/DailyPlanner/Services/NotificationService.cs
@@ -23,7 +23,11 @@ public static class NotificationService
         _checkTimer.Start();
     }
 
-    public static void Stop() => _checkTimer.Stop();
+    public static void Stop()
+    {
+        _checkTimer.Tick -= OnCheck;
+        _checkTimer.Stop();
+    }
 
     private static void OnCheck(object? sender, EventArgs e)
     {

--- a/DailyPlanner/Services/PlannerService.cs
+++ b/DailyPlanner/Services/PlannerService.cs
@@ -455,10 +455,14 @@ public sealed class PlannerService
         await db.SaveChangesAsync(ct);
 
         // Carry over subtasks (batch — one SaveChanges for all)
+        var targetLookup = toDay.Tasks
+            .Where(t => t.ParentTaskId is null)
+            .GroupBy(t => t.Text)
+            .ToDictionary(g => g.Key, g => g.First());
+
         foreach (var task in incomplete)
         {
-            var target = toDay.Tasks.FirstOrDefault(t => t.Text == task.Text && t.ParentTaskId is null)
-                         ?? toDay.Tasks.Last(t => t.Text == task.Text);
+            if (!targetLookup.TryGetValue(task.Text, out var target)) continue;
             foreach (var sub in task.SubTasks.Where(s => !s.IsCompleted && !string.IsNullOrWhiteSpace(s.Text)).OrderBy(s => s.Order))
             {
                 db.DailyTasks.Add(new DailyTask

--- a/DailyPlanner/Services/ThemeService.cs
+++ b/DailyPlanner/Services/ThemeService.cs
@@ -39,7 +39,7 @@ public static class ThemeService
                 if (Palettes.ContainsKey(name)) return name;
             }
         }
-        catch { /* fallback to default */ }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[ThemeService] Load failed: {ex.Message}"); }
         return "Catppuccin Mocha";
     }
 
@@ -51,7 +51,7 @@ public static class ThemeService
             Directory.CreateDirectory(dir);
             File.WriteAllText(SettingsPath, name);
         }
-        catch { /* non-critical */ }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[ThemeService] Save failed: {ex.Message}"); }
     }
 
     public static readonly Dictionary<string, ThemePalette> Palettes = new()

--- a/DailyPlanner/Services/UndoService.cs
+++ b/DailyPlanner/Services/UndoService.cs
@@ -105,6 +105,7 @@ public static class UndoService
                 var fadeIn = new DoubleAnimation(0, 1, TimeSpan.FromMilliseconds(250));
                 toast.BeginAnimation(UIElement.OpacityProperty, fadeIn);
 
+                _timer?.Stop();
                 _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(6) };
                 _timer.Tick += (_, _) =>
                 {

--- a/DailyPlanner/Services/UpdateService.cs
+++ b/DailyPlanner/Services/UpdateService.cs
@@ -15,7 +15,7 @@ public sealed class UpdateService
 
     public bool IsInstalled => _manager.IsInstalled;
 
-    public async Task<UpdateInfo?> CheckForUpdatesAsync()
+    public async Task<UpdateInfo?> CheckForUpdatesAsync(CancellationToken ct = default)
     {
         try
         {
@@ -28,7 +28,7 @@ public sealed class UpdateService
         }
     }
 
-    public async Task DownloadAndApplyAsync(UpdateInfo update, Action<int>? progress = null)
+    public async Task DownloadAndApplyAsync(UpdateInfo update, Action<int>? progress = null, CancellationToken ct = default)
     {
         await _manager.DownloadUpdatesAsync(update, progress);
         _manager.ApplyUpdatesAndRestart(update);

--- a/DailyPlanner/ViewModels/BudgetViewModel.cs
+++ b/DailyPlanner/ViewModels/BudgetViewModel.cs
@@ -31,7 +31,7 @@ public sealed partial class BudgetViewModel : ObservableObject
     public bool IsWarning => ProgressPercent >= 80 && !IsOverBudget;
     public string RemainingText => IsOverBudget
         ? $"{Loc.Get("OverBudget")}: {SpentAmount - Amount:N2}"
-        : $"{Loc.Get("Remaining")}: {RemainingAmount:N2}";
+        : $"{Loc.Get("FinRemaining")}: {RemainingAmount:N2}";
     public bool ShowWarning => IsOverBudget || IsWarning;
     public string WarningText => IsOverBudget
         ? Loc.Get("OverBudget")

--- a/DailyPlanner/ViewModels/MainViewModel.cs
+++ b/DailyPlanner/ViewModels/MainViewModel.cs
@@ -342,8 +342,9 @@ public sealed partial class MainViewModel : ObservableObject
             await testDb.OpenAsync();
             await testDb.CloseAsync();
         }
-        catch
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"[MainVM] Invalid backup: {ex.Message}");
             NotificationService.ShowToast(Loc.Get("RestoreTitle"), Loc.Get("RestoreInvalidDb"));
             return;
         }
@@ -364,8 +365,9 @@ public sealed partial class MainViewModel : ObservableObject
             if (File.Exists(walPath)) File.Delete(walPath);
             if (File.Exists(shmPath)) File.Delete(shmPath);
         }
-        catch
+        catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"[MainVM] Restore failed: {ex.Message}");
             // Restore from safety backup if copy failed
             if (File.Exists(backupPath))
                 File.Copy(backupPath, dbPath, true);
@@ -680,6 +682,12 @@ public sealed partial class MainViewModel : ObservableObject
                 }
             }
         }
+    }
+
+    public void Cleanup()
+    {
+        Loc.LanguageChanged -= OnLanguageChanged;
+        _reminderTimer?.Stop();
     }
 }
 

--- a/DailyPlanner/ViewModels/StatisticsViewModel.cs
+++ b/DailyPlanner/ViewModels/StatisticsViewModel.cs
@@ -93,7 +93,12 @@ public sealed partial class StatisticsViewModel : ObservableObject
                 wTasks.Count(t => t.IsCompleted)));
         }
 
-        // Week comparison
+        // Week comparison — reset before conditional assignment
+        CurrentWeekTasks = 0;
+        CurrentWeekCompleted = 0;
+        PreviousWeekTasks = 0;
+        PreviousWeekCompleted = 0;
+
         var today = DateOnly.FromDateTime(DateTime.Today);
         var currentStart = PlannerService.GetWeekStart(today);
         var prevStart = currentStart.AddDays(-7);

--- a/DailyPlanner/ViewModels/WeekViewModel.cs
+++ b/DailyPlanner/ViewModels/WeekViewModel.cs
@@ -142,6 +142,9 @@ public sealed partial class WeekViewModel : ObservableObject
     private async Task RemoveGoalAsync(GoalViewModel? goalVm)
     {
         if (goalVm is null) return;
+        // Note: PropertyChanged handler on goalVm is not explicitly unsubscribed here.
+        // This is acceptable because the handler is a lambda capturing 'this' (the WeekViewModel),
+        // and the GoalViewModel is removed from Goals collection, so it will be GC'd together with its parent.
         var model = _model.Goals.FirstOrDefault(g => g.Id == goalVm.Model.Id);
         if (model is not null)
         {

--- a/DailyPlanner/Views/FinancePage.xaml
+++ b/DailyPlanner/Views/FinancePage.xaml
@@ -448,7 +448,7 @@
                                                          Style="{DynamicResource AccentProgressBar}"/>
                                             <DockPanel>
                                                 <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" VerticalAlignment="Center">
-                                                    <Run Text="{Binding [Remaining], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
+                                                    <Run Text="{Binding [FinRemaining], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
                                                     <Run Text=": "/>
                                                     <Run Text="{Binding RemainingAmount, StringFormat=N2, Mode=OneWay}" FontWeight="SemiBold"/>
                                                 </TextBlock>
@@ -517,7 +517,7 @@
                                                          Style="{DynamicResource AccentProgressBar}"/>
                                             <DockPanel>
                                                 <TextBlock FontSize="11" Foreground="{DynamicResource MutedBrush}" VerticalAlignment="Center">
-                                                    <Run Text="{Binding [Remaining], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
+                                                    <Run Text="{Binding [FinRemaining], Source={x:Static svc:Loc.Instance}, Mode=OneWay}"/>
                                                     <Run Text=": "/>
                                                     <Run Text="{Binding RemainingAmount, StringFormat=N2, Mode=OneWay}" FontWeight="SemiBold"/>
                                                 </TextBlock>

--- a/DailyPlanner/Views/MyDayDialog.xaml
+++ b/DailyPlanner/Views/MyDayDialog.xaml
@@ -9,9 +9,17 @@
         Width="480" SizeToContent="Height" MaxHeight="600"
         ResizeMode="NoResize" ShowInTaskbar="False">
 
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="VisConv"/>
+        <Style TargetType="Window">
+            <Setter Property="FontFamily" Value="Segoe UI"/>
+        </Style>
+    </Window.Resources>
+
     <Border CornerRadius="16" Padding="24,20"
             Background="{DynamicResource CardBg}"
             BorderBrush="{DynamicResource AccentBrush}" BorderThickness="1">
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <StackPanel>
             <!-- Header -->
             <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
@@ -130,12 +138,6 @@
                           Foreground="{DynamicResource MutedBrush}" VerticalAlignment="Center"/>
             </DockPanel>
         </StackPanel>
+        </ScrollViewer>
     </Border>
-
-    <Window.Resources>
-        <BooleanToVisibilityConverter x:Key="VisConv"/>
-        <Style TargetType="Window">
-            <Setter Property="FontFamily" Value="Segoe UI"/>
-        </Style>
-    </Window.Resources>
 </Window>


### PR DESCRIPTION
## Summary
- Fix 3 duplicate Loc keys (`Remaining`, `Overdue`, `CatHealth`) causing incorrect translations — renamed to `FinRemaining`, `FinOverdue`, `CatHealthTip`
- Add global `DispatcherUnhandledException` handler with crash.log for crash diagnostics
- Replace 10+ bare `catch { }` blocks across App.xaml.cs, MainWindow, MainViewModel, ThemeService, Loc with proper `Debug.WriteLine` logging
- Fix memory leak in MainViewModel: add `Cleanup()` that unsubscribes `Loc.LanguageChanged` and stops `_reminderTimer`
- Fix NotificationService: unsubscribe `Tick` handler on `Stop()` to prevent stale subscriptions
- Fix DebounceService: move `TryRemove` to `finally` block preventing CTS dictionary leaks
- Fix UndoService: stop previous timer before creating new one to prevent orphaned timers
- Fix `CarryOverTasksAsync` O(n²) → O(n) using Dictionary lookup instead of repeated LINQ
- Fix backup rotation: sort by file creation time instead of filename string comparison
- Fix MyDayDialog: move `Window.Resources` before content (VisConv used before declared), add ScrollViewer for overflow
- Fix StatisticsViewModel: reset week comparison values on reload preventing stale data
- Add CI/CD GitHub Actions workflow (build verification on push/PR to master)

## Test plan
- [ ] Verify Finance page loads with correct localized category names and no duplicate key issues
- [ ] Verify app catches unhandled exceptions and writes to crash.log
- [ ] Switch themes and languages, verify no errors in Debug output
- [ ] Open/close Finance, Statistics pages multiple times — check memory doesn't grow
- [ ] Carry over tasks between days — verify performance
- [ ] Open MyDayDialog with many tasks — verify scroll works
- [ ] Verify GitHub Actions build passes on PR