### PR TITLE
v3.0.1: Fix ProgressBar crash + thread safety

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml
+++ b/DailyPlanner/MainWindow.xaml
@@ -392,7 +392,7 @@
                 <TextBlock Text="{Binding TimeDisplay}" FontSize="42" FontWeight="Bold"
                            HorizontalAlignment="Center" FontFamily="Cascadia Code, Consolas"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
-                <ProgressBar Value="{Binding ProgressPercent}" Maximum="100" Height="3" Margin="0,8,0,8"
+                <ProgressBar Value="{Binding ProgressPercent, Mode=OneWay}" Maximum="100" Height="3" Margin="0,8,0,8"
                              Style="{StaticResource DayProgressBar}"/>
 
                 <!-- Timer Settings -->

--- a/DailyPlanner/Services/NotificationService.cs
+++ b/DailyPlanner/Services/NotificationService.cs
@@ -32,10 +32,13 @@ public static class NotificationService
     private static void OnCheck(object? sender, EventArgs e)
     {
         var today = DateOnly.FromDateTime(DateTime.Today);
-        if (today != _lastCheckDate)
+        lock (_lock)
         {
-            lock (_lock) { _notifiedToday.Clear(); }
-            _lastCheckDate = today;
+            if (today != _lastCheckDate)
+            {
+                _notifiedToday.Clear();
+                _lastCheckDate = today;
+            }
         }
         // Notification check delegated to MainViewModel
     }

--- a/DailyPlanner/Services/UpdateService.cs
+++ b/DailyPlanner/Services/UpdateService.cs
@@ -19,7 +19,7 @@ public sealed class UpdateService
     {
         try
         {
-            return await _manager.CheckForUpdatesAsync();
+            return await _manager.CheckForUpdatesAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -30,7 +30,7 @@ public sealed class UpdateService
 
     public async Task DownloadAndApplyAsync(UpdateInfo update, Action<int>? progress = null, CancellationToken ct = default)
     {
-        await _manager.DownloadUpdatesAsync(update, progress);
+        await _manager.DownloadUpdatesAsync(update, progress).ConfigureAwait(false);
         _manager.ApplyUpdatesAndRestart(update);
     }
 }

--- a/DailyPlanner/Views/FinancePage.xaml
+++ b/DailyPlanner/Views/FinancePage.xaml
@@ -72,6 +72,7 @@
             <Setter Property="FontSize" Value="11"/>
             <Setter Property="Padding" Value="2,1"/>
             <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}"/>
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="MinWidth" Value="90"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
@@ -456,7 +457,7 @@
                                                     <Run Text="{Binding Amount, StringFormat=N2, Mode=OneWay}"/>
                                                 </TextBlock>
                                             </DockPanel>
-                                            <ProgressBar Value="{Binding ProgressPercent}" Maximum="100"
+                                            <ProgressBar Value="{Binding ProgressPercent, Mode=OneWay}" Maximum="100"
                                                          Height="4" Margin="0,8,0,0"
                                                          Foreground="{Binding ProgressPercent, Converter={StaticResource BudgetBrushConv}}"
                                                          Style="{DynamicResource BudgetProgressBar}"/>
@@ -555,7 +556,7 @@
                                                     </StackPanel>
                                                 </StackPanel>
                                             </DockPanel>
-                                            <ProgressBar Value="{Binding ProgressPercent}" Maximum="100"
+                                            <ProgressBar Value="{Binding ProgressPercent, Mode=OneWay}" Maximum="100"
                                                          Height="4" Margin="0,10,0,6"
                                                          Style="{DynamicResource AccentProgressBar}"/>
                                             <DockPanel>
@@ -631,7 +632,7 @@
                                                     </StackPanel>
                                                 </StackPanel>
                                             </DockPanel>
-                                            <ProgressBar Value="{Binding ProgressPercent}" Maximum="100"
+                                            <ProgressBar Value="{Binding ProgressPercent, Mode=OneWay}" Maximum="100"
                                                          Height="4" Margin="0,10,0,6"
                                                          Style="{DynamicResource AccentProgressBar}"/>
                                             <DockPanel>
@@ -814,7 +815,7 @@
                                                     </Grid>
                                                 </StackPanel>
                                             </DockPanel>
-                                            <ProgressBar Value="{Binding ProgressPercent}" Maximum="100"
+                                            <ProgressBar Value="{Binding ProgressPercent, Mode=OneWay}" Maximum="100"
                                                          Height="6" Margin="0,10,0,4"
                                                          Style="{DynamicResource AccentProgressBar}"/>
                                             <DockPanel>
@@ -1175,7 +1176,7 @@
                                        Foreground="{DynamicResource InfoBrush}" VerticalAlignment="Center">
                                 <Run Text="{Binding SavingsRatePercent, StringFormat=N1, Mode=OneWay}"/><Run Text="%"/>
                             </TextBlock>
-                            <ProgressBar Value="{Binding SavingsRatePercent}" Maximum="100"
+                            <ProgressBar Value="{Binding SavingsRatePercent, Mode=OneWay}" Maximum="100"
                                          Height="10" Margin="0,0,20,0"
                                          Style="{DynamicResource AccentProgressBar}"/>
                         </DockPanel>

--- a/DailyPlanner/Views/SettingsPage.xaml
+++ b/DailyPlanner/Views/SettingsPage.xaml
@@ -100,7 +100,7 @@
                                        Visibility="{Binding IsUpdateAvailable, Converter={StaticResource VisConv}}"/>
                         </StackPanel>
                     </DockPanel>
-                    <ProgressBar Value="{Binding UpdateProgress}" Maximum="100" Height="3"
+                    <ProgressBar Value="{Binding UpdateProgress, Mode=OneWay}" Maximum="100" Height="3"
                                  Visibility="{Binding IsUpdateAvailable, Converter={StaticResource VisConv}}"
                                  Foreground="{DynamicResource AccentBrush}"
                                  Background="{DynamicResource InputBgBrush}"


### PR DESCRIPTION
## Summary
- Fix **ProgressBar TwoWay binding crash** — `ProgressPercent` is read-only, ProgressBar.Value defaults to TwoWay → cascade of MessageBox errors. Added `Mode=OneWay` on all 7 ProgressBar bindings
- Fix **NotificationService race condition** — `_lastCheckDate` write moved inside lock
- Fix **UpdateService** — added `ConfigureAwait(false)` on async calls
- Fix **CompactDatePicker** dark theme — added `Foreground=TextPrimaryBrush` for date visibility

## Test plan
- [ ] Open Expenses tab with budgets — no crash
- [ ] Pomodoro timer progress bar works
- [ ] Settings update progress bar works
- [ ] DatePicker text visible on dark theme
- [ ] App runs overnight without notification issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)