### PR TITLE
v3.2.1: Fix crash — invalid SymbolRegular icons

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml
+++ b/DailyPlanner/MainWindow.xaml
@@ -148,7 +148,7 @@
                             </Style>
                         </ui:Button.Style>
                     </ui:Button>
-                    <ui:Button Content="{Binding [InboxTitle], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon Inbox24}"
+                    <ui:Button Content="{Binding [InboxTitle], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon MailInbox24}"
                                HorizontalAlignment="Stretch"
                                Click="Inbox_Click" Margin="0,0,0,4">
                         <ui:Button.Style>

--- a/DailyPlanner/Views/InboxPage.xaml
+++ b/DailyPlanner/Views/InboxPage.xaml
@@ -73,7 +73,7 @@
                         <!-- Empty state -->
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
                                     Visibility="{Binding HasTasks, Converter={StaticResource VisConv}, ConverterParameter=Invert}">
-                            <ui:SymbolIcon Symbol="Inbox24" FontSize="40"
+                            <ui:SymbolIcon Symbol="MailInbox24" FontSize="40"
                                            Foreground="{DynamicResource TextTertiaryBrush}"
                                            HorizontalAlignment="Center" Margin="0,0,0,10"/>
                             <TextBlock Text="{Binding [InboxEmpty], Source={x:Static svc:Loc.Instance}}"

--- a/DailyPlanner/Views/SettingsPage.xaml
+++ b/DailyPlanner/Views/SettingsPage.xaml
@@ -112,7 +112,7 @@
             <Border Style="{StaticResource PlannerCard}" Margin="0,0,0,12" Padding="20">
                 <StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                        <ui:SymbolIcon Symbol="BoardSplit24" FontSize="18" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                        <ui:SymbolIcon Symbol="AppsList24" FontSize="18" Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center" Margin="0,0,10,0"/>
                         <StackPanel>
                             <TextBlock Text="{Binding [TrelloIntegration], Source={x:Static svc:Loc.Instance}}" FontSize="15" FontWeight="SemiBold"/>
                             <TextBlock Text="{Binding [TrelloDesc], Source={x:Static svc:Loc.Instance}}" FontSize="11"


### PR DESCRIPTION
Hotfix for v3.2.0 crash on startup. Replaces non-existent WPF-UI icons (Inbox24, BoardSplit24) with valid ones (MailInbox24, AppsList24).