### PR TITLE
v3.3.1: Liquid Glass Dark

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml
+++ b/DailyPlanner/MainWindow.xaml
@@ -9,7 +9,9 @@
         Width="1480" Height="920"
         MinWidth="1200" MinHeight="700"
         WindowStartupLocation="CenterScreen"
-        ExtendsContentIntoTitleBar="True">
+        ExtendsContentIntoTitleBar="True"
+        WindowBackdropType="Mica"
+        Background="Transparent">
 
     <ui:FluentWindow.Resources>
         <conv:BoolToVisibilityConverter x:Key="VisConv"/>

--- a/DailyPlanner/Services/ThemeService.cs
+++ b/DailyPlanner/Services/ThemeService.cs
@@ -54,16 +54,27 @@ public static class ThemeService
         catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[ThemeService] Save failed: {ex.Message}"); }
     }
 
+    private static Color Argb(byte a, string hex)
+    {
+        var c = Hex(hex);
+        return Color.FromArgb(a, c.R, c.G, c.B);
+    }
+
     public static readonly Dictionary<string, ThemePalette> Palettes = new()
     {
-        // Modern Dark Minimal — violet accent, deep cool neutrals
+        // Liquid Glass Dark — glassmorphism over Mica backdrop, violet accent
         ["Dark"] = new("Dark", true,
-            Accent: Hex("#7C3AED"), AccentLight: Hex("#A78BFA"), AccentDark: Hex("#6D28D9"),
-            PageBg: Hex("#0E0E12"), CardBg: Hex("#17171F"), CardBorder: Hex("#242432"),
-            SidebarBg: Hex("#0A0A0F"), InputBg: Hex("#1A1A24"), SubtleBg: Hex("#20202B"),
-            Text: Hex("#F5F5FA"), Muted: Hex("#7E7E99"), CheckBorder: Hex("#343444"),
-            HoverBg: Hex("#27273A"), ProgressTrack: Hex("#1A1A24"), KeyboardBg: Hex("#24242F"),
-            Success: Hex("#10B981"), Warning: Hex("#F59E0B"), Danger: Hex("#EF4444"), Info: Hex("#3B82F6")),
+            Accent: Hex("#8B5CF6"), AccentLight: Hex("#C4B5FD"), AccentDark: Hex("#6D28D9"),
+            PageBg: Argb(0x00, "#0E0E12"),           // transparent — Mica shows through
+            CardBg: Argb(0x14, "#FFFFFF"),           // 8% white frosted glass
+            CardBorder: Argb(0x26, "#FFFFFF"),       // 15% white highlight edge
+            SidebarBg: Argb(0x4D, "#0A0A0F"),        // 30% darker panel
+            InputBg: Argb(0x1F, "#FFFFFF"),          // 12% white input fill
+            SubtleBg: Argb(0x0A, "#FFFFFF"),         // 4% white subtle
+            Text: Hex("#F5F5FA"), Muted: Hex("#9CA0B8"), CheckBorder: Argb(0x40, "#FFFFFF"),
+            HoverBg: Argb(0x1F, "#FFFFFF"), ProgressTrack: Argb(0x1A, "#FFFFFF"),
+            KeyboardBg: Argb(0x1F, "#FFFFFF"),
+            Success: Hex("#34D399"), Warning: Hex("#FBBF24"), Danger: Hex("#F87171"), Info: Hex("#60A5FA")),
 
         // Modern Light Minimal — same violet accent
         ["Light"] = new("Light", false,

--- a/DailyPlanner/Themes/DarkTheme.xaml
+++ b/DailyPlanner/Themes/DarkTheme.xaml
@@ -1,44 +1,54 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- Modern Dark Minimal (default). ThemeService overrides at runtime. -->
-    <SolidColorBrush x:Key="AccentBrush" Color="#7C3AED"/>
-    <SolidColorBrush x:Key="AccentLightBrush" Color="#A78BFA"/>
-    <SolidColorBrush x:Key="SuccessBrush" Color="#10B981"/>
-    <SolidColorBrush x:Key="WarningBrush" Color="#F59E0B"/>
-    <SolidColorBrush x:Key="DangerBrush" Color="#EF4444"/>
-    <SolidColorBrush x:Key="InfoBrush" Color="#3B82F6"/>
-    <SolidColorBrush x:Key="MutedBrush" Color="#7E7E99"/>
-    <SolidColorBrush x:Key="CardBg" Color="#17171F"/>
-    <SolidColorBrush x:Key="CardBorderBrush" Color="#242432"/>
-    <SolidColorBrush x:Key="InputBgBrush" Color="#1A1A24"/>
-    <SolidColorBrush x:Key="TodayGlowBrush" Color="#7C3AED"/>
+    <!-- Liquid Glass Dark (default). ThemeService overrides at runtime. -->
+    <SolidColorBrush x:Key="AccentBrush" Color="#8B5CF6"/>
+    <SolidColorBrush x:Key="AccentLightBrush" Color="#C4B5FD"/>
+    <SolidColorBrush x:Key="SuccessBrush" Color="#34D399"/>
+    <SolidColorBrush x:Key="WarningBrush" Color="#FBBF24"/>
+    <SolidColorBrush x:Key="DangerBrush" Color="#F87171"/>
+    <SolidColorBrush x:Key="InfoBrush" Color="#60A5FA"/>
+    <SolidColorBrush x:Key="MutedBrush" Color="#9CA0B8"/>
+    <SolidColorBrush x:Key="CardBg" Color="#14FFFFFF"/>
+    <SolidColorBrush x:Key="CardBorderBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="InputBgBrush" Color="#1FFFFFFF"/>
+    <SolidColorBrush x:Key="TodayGlowBrush" Color="#8B5CF6"/>
     <SolidColorBrush x:Key="TextPrimaryBrush" Color="#F5F5FA"/>
-    <SolidColorBrush x:Key="CheckBorderBrush" Color="#343444"/>
-    <SolidColorBrush x:Key="SubtleBgBrush" Color="#20202B"/>
-    <SolidColorBrush x:Key="FocusBgBrush" Color="#7C3AED" Opacity="0.12"/>
-    <SolidColorBrush x:Key="HoverBgBrush" Color="#27273A" Opacity="0.35"/>
-    <SolidColorBrush x:Key="ProgressTrackBrush" Color="#1A1A24"/>
-    <SolidColorBrush x:Key="KeyboardShortcutBg" Color="#24242F"/>
-    <SolidColorBrush x:Key="PageBgBrush" Color="#0E0E12"/>
-    <SolidColorBrush x:Key="SidebarBgBrush" Color="#0A0A0F"/>
-    <SolidColorBrush x:Key="MonthHoverBrush" Color="#7C3AED" Opacity="0.18"/>
-    <SolidColorBrush x:Key="MonthPressedBrush" Color="#27273A" Opacity="0.45"/>
+    <SolidColorBrush x:Key="CheckBorderBrush" Color="#40FFFFFF"/>
+    <SolidColorBrush x:Key="SubtleBgBrush" Color="#0AFFFFFF"/>
+    <SolidColorBrush x:Key="FocusBgBrush" Color="#8B5CF6" Opacity="0.18"/>
+    <SolidColorBrush x:Key="HoverBgBrush" Color="#1FFFFFFF"/>
+    <SolidColorBrush x:Key="ProgressTrackBrush" Color="#1AFFFFFF"/>
+    <SolidColorBrush x:Key="KeyboardShortcutBg" Color="#1FFFFFFF"/>
+    <SolidColorBrush x:Key="PageBgBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="SidebarBgBrush" Color="#4D0A0A0F"/>
+    <SolidColorBrush x:Key="MonthHoverBrush" Color="#8B5CF6" Opacity="0.22"/>
+    <SolidColorBrush x:Key="MonthPressedBrush" Color="#8B5CF6" Opacity="0.35"/>
 
-    <!-- Aliases used by new minimal screens -->
-    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#17171F"/>
-    <SolidColorBrush x:Key="BackgroundBrush" Color="#0E0E12"/>
-    <SolidColorBrush x:Key="BorderBrush" Color="#242432"/>
-    <SolidColorBrush x:Key="TextSecondaryBrush" Color="#A1A1B8"/>
-    <SolidColorBrush x:Key="TextTertiaryBrush" Color="#6B6B85"/>
+    <!-- Aliases -->
+    <SolidColorBrush x:Key="CardBackgroundBrush" Color="#14FFFFFF"/>
+    <SolidColorBrush x:Key="BackgroundBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="BorderBrush" Color="#26FFFFFF"/>
+    <SolidColorBrush x:Key="TextSecondaryBrush" Color="#CCF5F5FA"/>
+    <SolidColorBrush x:Key="TextTertiaryBrush" Color="#88F5F5FA"/>
 
-    <Color x:Key="AccentColor">#7C3AED</Color>
-    <Color x:Key="AccentLightColor">#A78BFA</Color>
+    <!-- Gradient accent brushes for buttons and highlights -->
+    <LinearGradientBrush x:Key="AccentGradientBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#A78BFA" Offset="0"/>
+        <GradientStop Color="#7C3AED" Offset="1"/>
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="GlassBorderBrush" StartPoint="0,0" EndPoint="1,1">
+        <GradientStop Color="#40FFFFFF" Offset="0"/>
+        <GradientStop Color="#10FFFFFF" Offset="1"/>
+    </LinearGradientBrush>
+
+    <Color x:Key="AccentColor">#8B5CF6</Color>
+    <Color x:Key="AccentLightColor">#C4B5FD</Color>
     <Color x:Key="AccentDarkColor">#6D28D9</Color>
-    <Color x:Key="SuccessColor">#10B981</Color>
-    <Color x:Key="WarningColor">#F59E0B</Color>
-    <Color x:Key="DangerColor">#EF4444</Color>
-    <Color x:Key="InfoColor">#3B82F6</Color>
+    <Color x:Key="SuccessColor">#34D399</Color>
+    <Color x:Key="WarningColor">#FBBF24</Color>
+    <Color x:Key="DangerColor">#F87171</Color>
+    <Color x:Key="InfoColor">#60A5FA</Color>
 
     <!-- Design tokens -->
     <FontFamily x:Key="MainFont">Segoe UI Variable, Segoe UI, sans-serif</FontFamily>
@@ -55,16 +65,21 @@
     <CornerRadius x:Key="RadiusMd">10</CornerRadius>
     <CornerRadius x:Key="RadiusLg">16</CornerRadius>
 
-    <!-- Card panel — minimal, subtle hover border tint -->
+    <!-- Liquid Glass card — frosted panel with soft accent glow on hover -->
     <Style x:Key="PlannerCard" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource CardBg}"/>
-        <Setter Property="CornerRadius" Value="10"/>
-        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}"/>
+        <Setter Property="CornerRadius" Value="14"/>
+        <Setter Property="BorderBrush" Value="{DynamicResource GlassBorderBrush}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="Padding" Value="16"/>
+        <Setter Property="Padding" Value="18"/>
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="True">
                 <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Color="#8B5CF6" BlurRadius="24" ShadowDepth="0" Opacity="0.3"/>
+                    </Setter.Value>
+                </Setter>
             </Trigger>
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
Second pass of redesign — applies 2026-style glassmorphism via Mica backdrop and alpha-based palette.