### PR TITLE
v3.13.0: Semantic colors + sidebar cleanup + Trello dedup

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.12.1</Version>
+    <Version>3.13.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml
+++ b/DailyPlanner/MainWindow.xaml
@@ -88,27 +88,6 @@
 
                 <!-- Bottom buttons -->
                 <StackPanel DockPanel.Dock="Bottom" Margin="12,0,12,16">
-                    <ui:Button Content="Pomodoro" Icon="{ui:SymbolIcon Timer24}"
-                               HorizontalAlignment="Stretch"
-                               Command="{Binding TogglePomodoroCommand}" Margin="0,0,0,4"
-                               ToolTip="Ctrl+P">
-                        <ui:Button.Style>
-                            <Style TargetType="ui:Button" BasedOn="{StaticResource {x:Type ui:Button}}">
-                                <Setter Property="Appearance" Value="Transparent"/>
-                                <Style.Triggers>
-                                    <DataTrigger Binding="{Binding IsPomodoroOpen}" Value="True">
-                                        <Setter Property="Background">
-                                            <Setter.Value>
-                                                <SolidColorBrush Color="{DynamicResource AccentColor}" Opacity="0.15"/>
-                                            </Setter.Value>
-                                        </Setter>
-                                        <Setter Property="BorderBrush" Value="{DynamicResource AccentBrush}"/>
-                                        <Setter Property="BorderThickness" Value="0,0,2,0"/>
-                                    </DataTrigger>
-                                </Style.Triggers>
-                            </Style>
-                        </ui:Button.Style>
-                    </ui:Button>
                     <ui:Button Content="{Binding [Statistics], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon DataBarVertical24}"
                                HorizontalAlignment="Stretch"
                                Click="Statistics_Click" Margin="0,0,0,4">
@@ -153,9 +132,6 @@
                     <ui:Button Content="{Binding [Export], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon ArrowDownload24}"
                                Appearance="Transparent" HorizontalAlignment="Stretch"
                                Command="{Binding ExportToExcelCommand}" Margin="0,0,0,4"/>
-                    <ui:Button Content="{Binding [TodayBtn], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon CalendarToday24}"
-                               Appearance="Transparent" HorizontalAlignment="Stretch"
-                               Command="{Binding GoToTodayCommand}" Margin="0,0,0,4"/>
                     <ui:Button Content="{Binding [Settings], Source={x:Static svc:Loc.Instance}}" Icon="{ui:SymbolIcon Settings24}"
                                HorizontalAlignment="Stretch"
                                Click="Settings_Click">

--- a/DailyPlanner/Services/PlannerService.Inbox.cs
+++ b/DailyPlanner/Services/PlannerService.Inbox.cs
@@ -86,7 +86,17 @@ public sealed partial class PlannerService
             db.DailyTasks.Add(target);
         }
 
-        db.InboxTasks.Remove(inbox);
+        // Archive Trello-sourced inbox tasks instead of deleting so SyncTrelloAsync
+        // knows this card was already placed and won't re-add it on the next sync.
+        if (inbox.Source == InboxSource.Trello && !string.IsNullOrEmpty(inbox.ExternalId))
+        {
+            inbox.IsArchived = true;
+            db.InboxTasks.Update(inbox);
+        }
+        else
+        {
+            db.InboxTasks.Remove(inbox);
+        }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
         return target;
     }

--- a/DailyPlanner/Services/ThemeService.cs
+++ b/DailyPlanner/Services/ThemeService.cs
@@ -74,7 +74,8 @@ public static class ThemeService
             Text: Hex("#FFFFFF"), Muted: Hex("#8E8E96"), CheckBorder: Argb(0x33, "#FFFFFF"),
             HoverBg: Argb(0x1A, "#FFFFFF"), ProgressTrack: Argb(0x14, "#FFFFFF"),
             KeyboardBg: Argb(0x14, "#FFFFFF"),
-            Success: Hex("#FFFFFF"), Warning: Hex("#E5E5E5"), Danger: Hex("#FF9999"), Info: Hex("#B8B8B8")),
+            // Semantic colors kept green/amber/red/blue so money and ratings stay readable
+            Success: Hex("#34D399"), Warning: Hex("#FBBF24"), Danger: Hex("#F87171"), Info: Hex("#60A5FA")),
 
         // Pure Monochrome Light
         ["Light"] = new("Light", false,
@@ -83,7 +84,7 @@ public static class ThemeService
             SidebarBg: Hex("#F5F5F5"), InputBg: Hex("#F5F5F5"), SubtleBg: Hex("#EFEFEF"),
             Text: Hex("#000000"), Muted: Hex("#6B6B6B"), CheckBorder: Hex("#D4D4D4"),
             HoverBg: Hex("#EBEBEB"), ProgressTrack: Hex("#E5E5E5"), KeyboardBg: Hex("#EFEFEF"),
-            Success: Hex("#000000"), Warning: Hex("#4A4A4A"), Danger: Hex("#991B1B"), Info: Hex("#525252")),
+            Success: Hex("#10B981"), Warning: Hex("#D97706"), Danger: Hex("#DC2626"), Info: Hex("#2563EB")),
     };
 
     public static void ApplyPalette(string name)


### PR DESCRIPTION
Green/red money, colored rating stars, remove Pomodoro/Today from sidebar, stop duplicating Trello cards on re-sync.