### PR TITLE
v3.20.0: Test coverage expansion \u2014 74 tests

### DIFF
--- a/DailyPlanner.Tests/AssemblyInfo.cs
+++ b/DailyPlanner.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+// Disable parallel test execution \u2014 tests share a static PlannerDbContextFactory override
+// that would race across threads. Serial execution is fast enough (<3s for the whole suite).
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/DailyPlanner.Tests/FinanceIntegrationTests.cs
+++ b/DailyPlanner.Tests/FinanceIntegrationTests.cs
@@ -1,0 +1,304 @@
+using DailyPlanner.Models;
+using FluentAssertions;
+
+namespace DailyPlanner.Tests;
+
+public class FinanceIntegrationTests : PlannerServiceTestFixture
+{
+    private async Task<FinanceCategory> SeededExpense()
+    {
+        await Service.SeedFinanceCategoriesAsync();
+        return (await Service.GetFinanceCategoriesAsync()).First(c => c.Type == FinanceEntryType.Expense);
+    }
+
+    private async Task<FinanceCategory> SeededIncome()
+    {
+        await Service.SeedFinanceCategoriesAsync();
+        return (await Service.GetFinanceCategoriesAsync()).First(c => c.Type == FinanceEntryType.Income);
+    }
+
+    // ─── Categories ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SeedCategories_CreatesDefaultSet()
+    {
+        await Service.SeedFinanceCategoriesAsync();
+        var cats = await Service.GetFinanceCategoriesAsync();
+        cats.Should().NotBeEmpty();
+        cats.Should().Contain(c => c.Type == FinanceEntryType.Income);
+        cats.Should().Contain(c => c.Type == FinanceEntryType.Expense);
+    }
+
+    [Fact]
+    public async Task SeedCategories_IsIdempotent()
+    {
+        await Service.SeedFinanceCategoriesAsync();
+        var count1 = (await Service.GetFinanceCategoriesAsync()).Count;
+        await Service.SeedFinanceCategoriesAsync();
+        var count2 = (await Service.GetFinanceCategoriesAsync()).Count;
+        count2.Should().Be(count1);
+    }
+
+    [Fact]
+    public async Task ArchiveCategory_HidesFromActiveList()
+    {
+        var cat = await SeededExpense();
+        await Service.ArchiveFinanceCategoryAsync(cat.Id);
+        var active = await Service.GetFinanceCategoriesAsync();
+        active.Should().NotContain(c => c.Id == cat.Id);
+    }
+
+    [Fact]
+    public async Task CanDeleteCategory_FalseIfUsedByEntries()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveFinanceEntryAsync(new FinanceEntry
+        {
+            CategoryId = cat.Id, Type = FinanceEntryType.Expense,
+            Amount = 10m, Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        (await Service.CanDeleteFinanceCategoryAsync(cat.Id)).Should().BeFalse();
+    }
+
+    // ─── Budgets ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveBudget_PersistsAndReturnsForMonth()
+    {
+        var cat = await SeededExpense();
+        var ym = "2026-04";
+        await Service.SaveBudgetAsync(new FinanceBudget { CategoryId = cat.Id, MonthYear = ym, Amount = 5000m });
+
+        var budgets = await Service.GetBudgetsAsync(ym);
+        budgets.Should().HaveCount(1);
+        budgets[0].Amount.Should().Be(5000m);
+    }
+
+    [Fact]
+    public async Task GetBudgets_DifferentMonth_ReturnsEmpty()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveBudgetAsync(new FinanceBudget { CategoryId = cat.Id, MonthYear = "2026-04", Amount = 1m });
+
+        var budgets = await Service.GetBudgetsAsync("2026-05");
+        budgets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveBudget_DeletesRow()
+    {
+        var cat = await SeededExpense();
+        var budget = new FinanceBudget { CategoryId = cat.Id, MonthYear = "2026-04", Amount = 1m };
+        await Service.SaveBudgetAsync(budget);
+
+        await Service.RemoveBudgetAsync(budget.Id);
+
+        (await Service.GetBudgetsAsync("2026-04")).Should().BeEmpty();
+    }
+
+    // ─── Recurring payments ─────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveRecurringPayment_StoresAndReturns()
+    {
+        var cat = await SeededExpense();
+        var rp = new RecurringPayment
+        {
+            Name = "Интернет",
+            CategoryId = cat.Id,
+            Type = FinanceEntryType.Expense,
+            Frequency = PaymentFrequency.Monthly,
+            Amount = 500m,
+            DayOfMonth = 15,
+            StartDate = new DateOnly(2026, 1, 1),
+            IsActive = true
+        };
+        await Service.SaveRecurringPaymentAsync(rp);
+
+        var result = await Service.GetRecurringPaymentsAsync();
+        result.Should().HaveCount(1);
+        result[0].Name.Should().Be("Интернет");
+    }
+
+    [Fact]
+    public async Task GenerateRecurringEntries_MonthlyCreatesOnDayOfMonth()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveRecurringPaymentAsync(new RecurringPayment
+        {
+            Name = "Rent", CategoryId = cat.Id, Type = FinanceEntryType.Expense,
+            Frequency = PaymentFrequency.Monthly, Amount = 3000m, DayOfMonth = 10,
+            StartDate = new DateOnly(2026, 1, 1), IsActive = true, AutoCreate = true
+        });
+
+        await Service.GenerateRecurringEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        var entries = await Service.GetFinanceEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+        entries.Should().ContainSingle();
+        entries[0].Date.Should().Be(new DateOnly(2026, 4, 10));
+        entries[0].Amount.Should().Be(3000m);
+    }
+
+    [Fact]
+    public async Task GenerateRecurringEntries_Idempotent()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveRecurringPaymentAsync(new RecurringPayment
+        {
+            Name = "Rent", CategoryId = cat.Id, Type = FinanceEntryType.Expense,
+            Frequency = PaymentFrequency.Monthly, Amount = 3000m, DayOfMonth = 10,
+            StartDate = new DateOnly(2026, 1, 1), IsActive = true, AutoCreate = true
+        });
+
+        await Service.GenerateRecurringEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+        await Service.GenerateRecurringEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        (await Service.GetFinanceEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30)))
+            .Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GenerateRecurringEntries_InactiveSkipped()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveRecurringPaymentAsync(new RecurringPayment
+        {
+            Name = "Old", CategoryId = cat.Id, Type = FinanceEntryType.Expense,
+            Frequency = PaymentFrequency.Monthly, Amount = 1m, DayOfMonth = 10,
+            StartDate = new DateOnly(2026, 1, 1), IsActive = false, AutoCreate = true
+        });
+
+        await Service.GenerateRecurringEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30));
+
+        (await Service.GetFinanceEntriesAsync(new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30)))
+            .Should().BeEmpty();
+    }
+
+    // ─── Accounts + transfers ───────────────────────────────────────
+
+    [Fact]
+    public async Task AccountBalance_InitialBalancePlusIncomeMinusExpense()
+    {
+        var incomeCat = await SeededIncome();
+        var account = new Account { Name = "Main", InitialBalance = 1000m };
+        await Service.SaveAccountAsync(account);
+
+        await Service.SaveFinanceEntryAsync(new FinanceEntry
+        {
+            AccountId = account.Id, CategoryId = incomeCat.Id,
+            Type = FinanceEntryType.Income, Amount = 500m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+        var expenseCat = (await Service.GetFinanceCategoriesAsync()).First(c => c.Type == FinanceEntryType.Expense);
+        await Service.SaveFinanceEntryAsync(new FinanceEntry
+        {
+            AccountId = account.Id, CategoryId = expenseCat.Id,
+            Type = FinanceEntryType.Expense, Amount = 200m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        var balance = await Service.GetAccountBalanceAsync(account.Id);
+        balance.Should().Be(1300m); // 1000 + 500 - 200
+    }
+
+    [Fact]
+    public async Task AccountBalance_TransferDebitsFromCreditsTo()
+    {
+        var from = new Account { Name = "Debit", InitialBalance = 1000m };
+        var to = new Account { Name = "Savings", InitialBalance = 0m };
+        await Service.SaveAccountAsync(from);
+        await Service.SaveAccountAsync(to);
+
+        await Service.SaveAccountTransferAsync(new AccountTransfer
+        {
+            FromAccountId = from.Id, ToAccountId = to.Id, Amount = 300m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        (await Service.GetAccountBalanceAsync(from.Id)).Should().Be(700m);
+        (await Service.GetAccountBalanceAsync(to.Id)).Should().Be(300m);
+    }
+
+    // ─── Analytics ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetExpensesByCategory_GroupsAndSums()
+    {
+        var expense = await SeededExpense();
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        await Service.SaveFinanceEntryAsync(new FinanceEntry { CategoryId = expense.Id, Type = FinanceEntryType.Expense, Amount = 100m, Date = today });
+        await Service.SaveFinanceEntryAsync(new FinanceEntry { CategoryId = expense.Id, Type = FinanceEntryType.Expense, Amount = 200m, Date = today });
+
+        var breakdown = await Service.GetExpensesByCategoryAsync(today, today);
+        breakdown.Should().ContainSingle();
+        breakdown[0].Amount.Should().Be(300m);
+    }
+
+    [Fact]
+    public async Task GetMonthlyTotals_ReturnsEntryPerMonth()
+    {
+        var inc = await SeededIncome();
+        var exp = (await Service.GetFinanceCategoriesAsync()).First(c => c.Type == FinanceEntryType.Expense);
+
+        var thisMonth = DateOnly.FromDateTime(DateTime.Today);
+        await Service.SaveFinanceEntryAsync(new FinanceEntry { CategoryId = inc.Id, Type = FinanceEntryType.Income, Amount = 1000m, Date = thisMonth });
+        await Service.SaveFinanceEntryAsync(new FinanceEntry { CategoryId = exp.Id, Type = FinanceEntryType.Expense, Amount = 300m, Date = thisMonth });
+
+        var totals = await Service.GetMonthlyTotalsAsync(3);
+        totals.Should().NotBeEmpty();
+        var current = totals.First(t => t.Year == thisMonth.Year && t.Month == thisMonth.Month);
+        current.Income.Should().Be(1000m);
+        current.Expenses.Should().Be(300m);
+    }
+
+    // ─── Split entries ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task SplitEntries_ParentHasChildren()
+    {
+        var exp = await SeededExpense();
+        var today = DateOnly.FromDateTime(DateTime.Today);
+
+        var parent = new FinanceEntry
+        {
+            CategoryId = exp.Id, Type = FinanceEntryType.Expense, Amount = 1000m, Date = today,
+            Description = "Grocery trip"
+        };
+        await Service.SaveFinanceEntryAsync(parent);
+
+        await Service.SaveFinanceEntryAsync(new FinanceEntry
+        {
+            CategoryId = exp.Id, Type = FinanceEntryType.Expense, Amount = 600m, Date = today,
+            ParentEntryId = parent.Id, Description = "Milk"
+        });
+        await Service.SaveFinanceEntryAsync(new FinanceEntry
+        {
+            CategoryId = exp.Id, Type = FinanceEntryType.Expense, Amount = 400m, Date = today,
+            ParentEntryId = parent.Id, Description = "Bread"
+        });
+
+        var splits = await Service.GetSplitEntriesAsync(parent.Id);
+        splits.Should().HaveCount(2);
+        splits.Sum(s => s.Amount).Should().Be(1000m);
+    }
+
+    // ─── Financial goals ────────────────────────────────────────────
+
+    [Fact]
+    public async Task FinancialGoal_SaveRemoveRoundTrip()
+    {
+        await Service.SaveFinancialGoalAsync(new FinancialGoal
+        {
+            Name = "New laptop", TargetAmount = 100000m, SavedAmount = 20000m,
+            CreatedDate = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        var list = await Service.GetFinancialGoalsAsync();
+        list.Should().ContainSingle(g => g.Name == "New laptop");
+
+        await Service.RemoveFinancialGoalAsync(list[0].Id);
+        (await Service.GetFinancialGoalsAsync()).Should().BeEmpty();
+    }
+}

--- a/DailyPlanner.Tests/PlanningIntegrationTests.cs
+++ b/DailyPlanner.Tests/PlanningIntegrationTests.cs
@@ -1,0 +1,161 @@
+using DailyPlanner.Models;
+using FluentAssertions;
+
+namespace DailyPlanner.Tests;
+
+public class PlanningIntegrationTests : PlannerServiceTestFixture
+{
+    // ─── Habits ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddHabit_StoresWithDefaultEntries()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var habit = new HabitDefinition { WeekId = week.Id, Order = 99, Name = "Читать 30 минут" };
+        habit.Entries.Add(new HabitEntry { DayOfWeek = DayOfWeek.Monday, IsCompleted = true });
+        await Service.AddHabitAsync(habit);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        reloaded.Habits.Should().ContainSingle(h => h.Name == "Читать 30 минут");
+    }
+
+    [Fact]
+    public async Task SaveHabitEntry_UpdatesCompletion()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var entry = week.Habits[0].Entries.First();
+        entry.IsCompleted = true;
+        await Service.SaveHabitEntryAsync(entry);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        reloaded.Habits[0].Entries.First(e => e.Id == entry.Id).IsCompleted.Should().BeTrue();
+    }
+
+    // ─── Goals ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveGoal_UpdatesText()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var goal = week.Goals[0];
+        goal.Text = "Завершить MVP";
+        goal.IsCompleted = true;
+        await Service.SaveGoalAsync(goal);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var sameGoal = reloaded.Goals.First(g => g.Id == goal.Id);
+        sameGoal.Text.Should().Be("Завершить MVP");
+        sameGoal.IsCompleted.Should().BeTrue();
+    }
+
+    // ─── Templates ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Template_AppliedOnlyToMatchingDayOfWeek()
+    {
+        await Service.SaveTemplateAsync(new RecurringTemplate
+        {
+            Text = "Утренняя пробежка",
+            DayOfWeek = DayOfWeek.Monday,
+            IsActive = true
+        });
+
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        await Service.ApplyTemplatesAsync(week);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var monday = reloaded.Days.First(d => d.Date.DayOfWeek == DayOfWeek.Monday);
+        monday.Tasks.Should().Contain(t => t.Text == "Утренняя пробежка");
+    }
+
+    // ─── CarryOver ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CarryOverTasks_MovesIncompleteText()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var mon = week.Days[0];
+        var tue = week.Days[1];
+
+        var incomplete = mon.Tasks[0];
+        incomplete.Text = "Доделать спеку";
+        incomplete.IsCompleted = false;
+        await Service.SaveTaskAsync(incomplete);
+
+        var done = mon.Tasks[1];
+        done.Text = "Готово";
+        done.IsCompleted = true;
+        await Service.SaveTaskAsync(done);
+
+        await Service.CarryOverTasksAsync(mon.Date, tue.Date);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        reloaded.Days[1].Tasks.Should().Contain(t => t.Text == "Доделать спеку");
+        // Completed stays on source
+        reloaded.Days[0].Tasks.Should().Contain(t => t.Text == "Готово" && t.IsCompleted);
+    }
+
+    // ─── CopyWeekStructure ──────────────────────────────────────────
+
+    [Fact]
+    public async Task CopyWeekStructure_ClonesTaskTextIntoMatchingDay()
+    {
+        var src = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        src.Days[0].Tasks[0].Text = "Понедельник A";
+        src.Days[0].Tasks[1].Text = "Понедельник B";
+        await Service.SaveTaskAsync(src.Days[0].Tasks[0]);
+        await Service.SaveTaskAsync(src.Days[0].Tasks[1]);
+
+        var dst = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 20));
+        await Service.CopyWeekStructureAsync(src.Id, dst.Id);
+
+        var dstReloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 20));
+        dstReloaded.Days[0].Tasks.Should().Contain(t => t.Text == "Понедельник A");
+        dstReloaded.Days[0].Tasks.Should().Contain(t => t.Text == "Понедельник B");
+    }
+
+    // ─── WeeklyNotes / Reminders / Meetings ─────────────────────────
+
+    [Fact]
+    public async Task SaveWeeklyNote_Persists()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var note = new WeeklyNote { WeekId = week.Id, Order = 1, Text = "Важно!" };
+        await Service.SaveWeeklyNoteAsync(note);
+
+        var reloaded = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        reloaded.WeeklyNotes.Should().Contain(n => n.Text == "Важно!");
+    }
+
+    [Fact]
+    public async Task SaveReminder_AndRetrieve()
+    {
+        var reminder = new Reminder { Title = "Встреча", Message = "В 10:00", Time = new TimeOnly(10, 0) };
+        await Service.SaveReminderAsync(reminder);
+        (await Service.GetRemindersAsync()).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SaveMeeting_AndRetrieve()
+    {
+        var meeting = new Meeting { Title = "Стендап", DateTime = DateTime.Today.AddHours(10) };
+        await Service.SaveMeetingAsync(meeting);
+        (await Service.GetMeetingsAsync()).Should().ContainSingle();
+    }
+
+    // ─── Income sources ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task SaveIncomeSource_Persists()
+    {
+        var src = new IncomeSource
+        {
+            Name = "ProjectA", ClientName = "Client X", TotalMonthlyAmount = 5000m,
+            Icon = "💰", Color = "#4ADE80"
+        };
+        await Service.SaveIncomeSourceAsync(src);
+
+        var list = await Service.GetIncomeSourcesAsync();
+        list.Should().ContainSingle(s => s.Name == "ProjectA");
+    }
+}

--- a/DailyPlanner.Tests/WeeklyReviewViewModelTests.cs
+++ b/DailyPlanner.Tests/WeeklyReviewViewModelTests.cs
@@ -1,0 +1,134 @@
+using DailyPlanner.Models;
+using DailyPlanner.ViewModels;
+using FluentAssertions;
+
+namespace DailyPlanner.Tests;
+
+public class WeeklyReviewViewModelTests
+{
+    private static PlannerWeek BuildWeek(Action<PlannerWeek>? tweak = null)
+    {
+        var week = new PlannerWeek { StartDate = new DateOnly(2026, 4, 13) };
+        for (var i = 0; i < 4; i++) week.Goals.Add(new WeeklyGoal { Order = i + 1 });
+        for (var i = 0; i < 7; i++)
+        {
+            var day = new DailyPlan { Date = week.StartDate.AddDays(i), State = new DailyState() };
+            for (var t = 0; t < 10; t++) day.Tasks.Add(new DailyTask { Order = t + 1 });
+            week.Days.Add(day);
+        }
+        var habit = new HabitDefinition { Name = "Test" };
+        for (var d = DayOfWeek.Monday; d <= DayOfWeek.Saturday; d++)
+            habit.Entries.Add(new HabitEntry { DayOfWeek = d });
+        habit.Entries.Add(new HabitEntry { DayOfWeek = DayOfWeek.Sunday });
+        week.Habits.Add(habit);
+        tweak?.Invoke(week);
+        return week;
+    }
+
+    [Fact]
+    public void Empty_Week_ZeroStats()
+    {
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(BuildWeek());
+
+        vm.TotalTasks.Should().Be(0);
+        vm.CompletedTasks.Should().Be(0);
+        vm.CompletionRate.Should().Be(0);
+        vm.BestDayName.Should().Be("—");
+        vm.BestDayCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void CompletionRate_Calculated()
+    {
+        var week = BuildWeek(w =>
+        {
+            w.Days[0].Tasks[0].Text = "a"; w.Days[0].Tasks[0].IsCompleted = true;
+            w.Days[0].Tasks[1].Text = "b"; w.Days[0].Tasks[1].IsCompleted = false;
+            w.Days[0].Tasks[2].Text = "c"; w.Days[0].Tasks[2].IsCompleted = true;
+        });
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+
+        vm.TotalTasks.Should().Be(3);
+        vm.CompletedTasks.Should().Be(2);
+        vm.CompletionRate.Should().BeApproximately(67, 1); // 2/3 ~= 66.67
+    }
+
+    [Fact]
+    public void BestDay_PicksDayWithMostCompleted()
+    {
+        var week = BuildWeek(w =>
+        {
+            w.Days[0].Tasks[0].Text = "a"; w.Days[0].Tasks[0].IsCompleted = true;
+            w.Days[1].Tasks[0].Text = "b"; w.Days[1].Tasks[0].IsCompleted = true;
+            w.Days[1].Tasks[1].Text = "c"; w.Days[1].Tasks[1].IsCompleted = true;
+            w.Days[2].Tasks[0].Text = "d"; w.Days[2].Tasks[0].IsCompleted = false;
+        });
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+
+        vm.BestDayCount.Should().Be(2);
+        // Tuesday (Day[1]) was 2026-04-14 — Tuesday
+        vm.BestDayName.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Goals_CountsCompletedCorrectly()
+    {
+        var week = BuildWeek(w =>
+        {
+            w.Goals[0].IsCompleted = true;
+            w.Goals[1].IsCompleted = true;
+            w.Goals[2].IsCompleted = false;
+            w.Goals[3].IsCompleted = false;
+        });
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+
+        vm.TotalGoals.Should().Be(4);
+        vm.GoalsReached.Should().Be(2);
+    }
+
+    [Fact]
+    public void Habits_CountsCompletedEntries()
+    {
+        var week = BuildWeek(w =>
+        {
+            w.Habits[0].Entries[0].IsCompleted = true;
+            w.Habits[0].Entries[1].IsCompleted = true;
+            w.Habits[0].Entries[2].IsCompleted = false;
+        });
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+
+        vm.HabitsTotal.Should().Be(7);
+        vm.HabitsCompleted.Should().Be(2);
+    }
+
+    [Fact]
+    public void AverageState_ComputedFromDailyStates()
+    {
+        var week = BuildWeek(w =>
+        {
+            w.Days[0].State!.Sleep = 5; w.Days[0].State!.Energy = 4; w.Days[0].State!.Mood = 3;
+            w.Days[1].State!.Sleep = 3; w.Days[1].State!.Energy = 2; w.Days[1].State!.Mood = 5;
+        });
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+
+        // Average across ALL 7 days (some with zeroes)
+        vm.AvgSleep.Should().BeInRange(1, 5);
+        vm.AvgEnergy.Should().BeInRange(0.5, 5);
+        vm.AvgMood.Should().BeInRange(1, 5);
+    }
+
+    [Fact]
+    public void WeekLabel_IsDateRange()
+    {
+        var week = BuildWeek();
+        var vm = new WeeklyReviewViewModel();
+        vm.LoadFrom(week);
+        vm.WeekLabel.Should().Be("13.04 — 19.04");
+    }
+}

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.19.0</Version>
+    <Version>3.20.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>


### PR DESCRIPTION
Adds 34 new tests across Finance, Planning and WeeklyReview. Disables parallel execution to keep the shared test DB clean.