### PR TITLE
Fix CI build and align WeekPage content padding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
           dotnet-version: '10.0.x'
           dotnet-quality: 'preview'
 
-      - name: Restore main
-        run: dotnet restore DailyPlanner/DailyPlanner.csproj -r win-x64
-
       - name: Restore tests
         run: dotnet restore DailyPlanner.Tests/DailyPlanner.Tests.csproj
+
+      - name: Restore main
+        run: dotnet restore DailyPlanner/DailyPlanner.csproj -r win-x64
 
       - name: Build
         run: dotnet build DailyPlanner/DailyPlanner.csproj --no-restore -c Release -r win-x64

--- a/DailyPlanner/Views/WeekPage.xaml
+++ b/DailyPlanner/Views/WeekPage.xaml
@@ -26,7 +26,7 @@
     </Page.Resources>
 
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="8,0,8,24" DataContext="{Binding SelectedWeek}">
+        <StackPanel Margin="24,0,24,24" DataContext="{Binding SelectedWeek}">
 
             <!-- STAT CARDS with tooltips -->
             <Grid Margin="0,0,0,20">


### PR DESCRIPTION
## Summary
- **CI fix:** swap restore order — restore Tests first (без RID), потом main с `-r win-x64`. Иначе транзитивный restore через ProjectReference перезаписывал assets.json главного проекта без RID-target, из-за чего `build --no-restore -r win-x64` падал с NETSDK1047.
- **UI fix:** WeekPage content margin `8,0,8,24` → `24,0,24,24`. Теперь боковые отступы контента совпадают с верхней навигацией (24px), карточки не прижаты к правому краю.

## Test plan
- [x] Локально воспроизведена ошибка CI, фикс подтверждён
- [x] `dotnet build -c Release -r win-x64` — OK
- [x] `dotnet test` — 74/74 passed
- [ ] GitHub Actions зелёный