### PR TITLE
v3.21.0: Single-instance guard + README + comment cleanup

### DIFF
--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -11,6 +11,13 @@ public partial class App : Application
 {
     protected override async void OnStartup(StartupEventArgs e)
     {
+        if (!SingleInstanceGuard.TryAcquire(out _))
+        {
+            SingleInstanceGuard.SignalExistingInstance();
+            Shutdown();
+            return;
+        }
+
         DispatcherUnhandledException += (_, e) =>
         {
             Log.Error("App", $"Unhandled: {e.Exception}");
@@ -27,18 +34,19 @@ public partial class App : Application
             e.Handled = true;
         };
 
+        Exit += (_, _) => SingleInstanceGuard.Release();
+
         base.OnStartup(e);
 
-        // Velopack: handle install/uninstall/update hooks (creates shortcuts, etc.)
         VelopackApp.Build().Run();
 
-        // DI container — initialize before anything that resolves services
         ServiceHost.Configure();
 
-        // Apply theme resources (must run AFTER WPF-UI loads but BEFORE window renders)
+        // Must run AFTER WPF-UI loads but BEFORE window renders
         ThemeService.Apply();
 
-        // Show splash
+        SingleInstanceGuard.StartActivationListener(ActivateMainWindow);
+
         var splash = new Window
         {
             Width = 380,
@@ -115,7 +123,6 @@ public partial class App : Application
                     var backupName = $"planner_{DateTime.Now:yyyyMMdd_HHmmss}.db";
                     System.IO.File.Copy(dbPath, System.IO.Path.Combine(backupDir, backupName), true);
 
-                    // Rotate: keep only last 5 backups
                     var old = System.IO.Directory.GetFiles(backupDir, "planner_*.db")
                         .OrderByDescending(f => System.IO.File.GetCreationTimeUtc(f))
                         .Skip(5);
@@ -126,7 +133,6 @@ public partial class App : Application
             catch (Exception ex) { Log.Error("App", $"Backup failed: {ex.Message}"); }
         });
 
-        // Initialize DB
         try
         {
             await Task.Run(() =>
@@ -148,5 +154,18 @@ public partial class App : Application
         }
 
         splash.Close();
+    }
+
+    private void ActivateMainWindow()
+    {
+        if (MainWindow is null) return;
+
+        if (!MainWindow.IsVisible) MainWindow.Show();
+        if (MainWindow.WindowState == WindowState.Minimized) MainWindow.WindowState = WindowState.Normal;
+
+        MainWindow.Activate();
+        MainWindow.Topmost = true;
+        MainWindow.Topmost = false;
+        MainWindow.Focus();
     }
 }

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.20.0</Version>
+    <Version>3.21.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml.cs
+++ b/DailyPlanner/MainWindow.xaml.cs
@@ -186,7 +186,6 @@ public partial class MainWindow : FluentWindow
 
     private void ShowMyDayDialog()
     {
-        // Check if user disabled it
         var settingsPath = System.IO.Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "DailyPlanner", "myday.txt");
@@ -207,7 +206,6 @@ public partial class MainWindow : FluentWindow
             var vm = new ViewModels.MyDayViewModel(_viewModel.SelectedWeek);
             var dialog = new MyDayDialog { DataContext = vm, Owner = this };
 
-            // Apply theme resources safely
             if (Application.Current?.Resources?.MergedDictionaries is { Count: > 0 } merged)
             {
                 foreach (var dict in merged)

--- a/DailyPlanner/Services/SingleInstanceGuard.cs
+++ b/DailyPlanner/Services/SingleInstanceGuard.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows;
+
+namespace DailyPlanner.Services;
+
+public static class SingleInstanceGuard
+{
+    private const string MutexName = @"Global\DailyPlanner_Mutex_c3f4a2e1";
+    private const string EventName = @"Global\DailyPlanner_Activate_c3f4a2e1";
+    private const int SW_RESTORE = 9;
+
+    private static Mutex? _mutex;
+    private static EventWaitHandle? _activationEvent;
+
+    public static bool TryAcquire(out bool alreadyRunning)
+    {
+        _mutex = new Mutex(true, MutexName, out var createdNew);
+        if (createdNew)
+        {
+            _activationEvent = new EventWaitHandle(false, EventResetMode.AutoReset, EventName);
+            alreadyRunning = false;
+            return true;
+        }
+
+        _mutex.Dispose();
+        _mutex = null;
+        alreadyRunning = true;
+        return false;
+    }
+
+    public static void SignalExistingInstance()
+    {
+        try
+        {
+            using var signal = EventWaitHandle.OpenExisting(EventName);
+            signal.Set();
+        }
+        catch
+        {
+            ActivateByWindowHandle();
+        }
+    }
+
+    public static void StartActivationListener(Action onActivate)
+    {
+        if (_activationEvent is null) return;
+
+        var thread = new Thread(() =>
+        {
+            while (_activationEvent.WaitOne())
+                Application.Current?.Dispatcher.BeginInvoke(onActivate);
+        })
+        {
+            IsBackground = true,
+            Name = "DailyPlanner.ActivationListener"
+        };
+        thread.Start();
+    }
+
+    public static void Release()
+    {
+        _activationEvent?.Dispose();
+        _mutex?.ReleaseMutex();
+        _mutex?.Dispose();
+    }
+
+    private static void ActivateByWindowHandle()
+    {
+        var current = Process.GetCurrentProcess();
+        foreach (var p in Process.GetProcessesByName(current.ProcessName))
+        {
+            if (p.Id == current.Id) continue;
+            var handle = p.MainWindowHandle;
+            if (handle == nint.Zero) continue;
+            if (IsIconic(handle)) ShowWindow(handle, SW_RESTORE);
+            SetForegroundWindow(handle);
+            return;
+        }
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetForegroundWindow(nint hWnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool ShowWindow(nint hWnd, int nCmdShow);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsIconic(nint hWnd);
+}

--- a/README.md
+++ b/README.md
@@ -92,9 +92,13 @@ Windows 10/11 x64. .NET 10 runtime is bundled in the self-contained build.
 
 | Key | Action |
 |---|---|
+| `Ctrl+←` / `Ctrl+→` | Previous / next month |
 | `Ctrl+T` | Jump to today |
-| `Ctrl+P` | Toggle Pomodoro |
 | `Ctrl+F` | Search |
+| `Ctrl+E` | Export to Excel |
+| `Ctrl+P` | Toggle Pomodoro |
+| `Ctrl+M` | Toggle Finance module |
+| `Ctrl+W` | Weekly review |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Single-instance guard:** запуск второй копии приложения теперь невозможен — вместо неё активируется уже запущенное окно (даже если оно свернуто в трей). Реализация: named Mutex + EventWaitHandle (IPC сигнал) + fallback через SetForegroundWindow для процесса с видимым окном.
- **README:** раздел Keyboard shortcuts приведён в соответствие с реальными InputBindings (Ctrl+←/→, Ctrl+E, Ctrl+M, Ctrl+W добавлены).
- **Чистка:** удалены очевидные WHAT-комментарии в App/MainWindow (`// Initialize DB`, `// Rotate: keep only last 5 backups`, `// Check if user disabled it`, `// Apply theme resources safely`, `// Show splash`).

## Test plan
- [x] `dotnet build -c Debug` — OK
- [x] `dotnet test` — 74/74 passed
- [ ] Ручная проверка: запустить приложение, затем попробовать запустить второй раз → должно активироваться существующее окно вместо нового
- [ ] Проверка с окном в трее: свернуть в трей, запустить exe → окно должно вернуться из трея

## Release
После мержа — сборка Velopack и публикация v3.21.0.