### PR TITLE
SECURITY.md: bump supported versions 2.x -> 3.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 2.x     | :white_check_mark: |
-| < 2.0   | :x:                |
+| 3.x     | :white_check_mark: |
+| < 3.0   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Устаревшая таблица — проект давно на 3.x, а в SECURITY.md значится только 2.x.