### PR TITLE
v3.22.0: Trello sync dedup + README refresh

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.21.0</Version>
+    <Version>3.22.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Data/PlannerDbContext.cs
+++ b/DailyPlanner/Data/PlannerDbContext.cs
@@ -64,7 +64,9 @@ public sealed class PlannerDbContext(DbContextOptions<PlannerDbContext> options)
             e.HasKey(t => t.Id);
             e.HasIndex(t => t.DailyPlanId);
             e.HasIndex(t => t.ParentTaskId);
+            e.HasIndex(t => t.ExternalId);
             e.Property(t => t.Text).HasMaxLength(500);
+            e.Property(t => t.ExternalId).HasMaxLength(100);
             e.HasOne(t => t.ParentTask)
                 .WithMany(t => t.SubTasks)
                 .HasForeignKey(t => t.ParentTaskId)

--- a/DailyPlanner/Migrations/20260420114613_AddDailyTaskExternalId.Designer.cs
+++ b/DailyPlanner/Migrations/20260420114613_AddDailyTaskExternalId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DailyPlanner.Migrations
 {
     [DbContext(typeof(PlannerDbContext))]
-    partial class PlannerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420114613_AddDailyTaskExternalId")]
+    partial class AddDailyTaskExternalId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.6");

--- a/DailyPlanner/Migrations/20260420114613_AddDailyTaskExternalId.cs
+++ b/DailyPlanner/Migrations/20260420114613_AddDailyTaskExternalId.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyPlanner.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDailyTaskExternalId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalId",
+                table: "DailyTasks",
+                type: "TEXT",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyTasks_ExternalId",
+                table: "DailyTasks",
+                column: "ExternalId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DailyTasks_ExternalId",
+                table: "DailyTasks");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalId",
+                table: "DailyTasks");
+        }
+    }
+}

--- a/DailyPlanner/Models/DailyTask.cs
+++ b/DailyPlanner/Models/DailyTask.cs
@@ -15,6 +15,7 @@ public sealed class DailyTask
     public TaskCategory Category { get; set; }
     public TimeOnly? ReminderTime { get; set; }
     public DateOnly? Deadline { get; set; }
+    public string? ExternalId { get; set; }
 
     public DailyPlan? DailyPlan { get; set; }
     public DailyTask? ParentTask { get; set; }

--- a/DailyPlanner/Services/PlannerService.Inbox.cs
+++ b/DailyPlanner/Services/PlannerService.Inbox.cs
@@ -62,6 +62,7 @@ public sealed partial class PlannerService
             .OrderBy(t => t.Order)
             .FirstOrDefaultAsync(ct).ConfigureAwait(false);
 
+        var externalId = inbox.Source == InboxSource.Trello ? inbox.ExternalId : null;
         DailyTask target;
         if (emptySlot is not null)
         {
@@ -69,6 +70,7 @@ public sealed partial class PlannerService
             emptySlot.Priority = inbox.Priority;
             emptySlot.Category = inbox.Category;
             emptySlot.Deadline = inbox.DueDate;
+            emptySlot.ExternalId = externalId;
             target = emptySlot;
         }
         else
@@ -81,7 +83,8 @@ public sealed partial class PlannerService
                 Text = inbox.Text,
                 Priority = inbox.Priority,
                 Category = inbox.Category,
-                Deadline = inbox.DueDate
+                Deadline = inbox.DueDate,
+                ExternalId = externalId
             };
             db.DailyTasks.Add(target);
         }
@@ -137,11 +140,15 @@ public sealed partial class PlannerService
         var cards = await trello.GetCardsInListByNameAsync(settings.ListName, settings.ApiKey, settings.Token, ct).ConfigureAwait(false);
 
         await using var db = PlannerDbContextFactory.Create();
-        var existingExternalIds = await db.InboxTasks
+        var inInbox = await db.InboxTasks
             .Where(t => t.Source == InboxSource.Trello && t.ExternalId != null)
             .Select(t => t.ExternalId!)
             .ToListAsync(ct).ConfigureAwait(false);
-        var existingSet = existingExternalIds.ToHashSet();
+        var placedInDays = await db.DailyTasks
+            .Where(t => t.ExternalId != null)
+            .Select(t => t.ExternalId!)
+            .ToListAsync(ct).ConfigureAwait(false);
+        var existingSet = inInbox.Concat(placedInDays).ToHashSet();
 
         var today = DateOnly.FromDateTime(DateTime.Today);
         var added = 0;

--- a/README.md
+++ b/README.md
@@ -1,90 +1,91 @@
-<h1 align="center">
-  <img src="DailyPlanner/planner.ico" width="56" alt="DailyPlanner icon"/>
-  <br/>
-  Daily &amp; Financial Planner
-</h1>
+<div align="center">
 
-<p align="center">
-  Monochrome weekly planner for Windows with finance tracker, Trello inbox, habits and Pomodoro — fully offline.
-</p>
+<img src="DailyPlanner/planner.ico" width="84" alt="Daily Planner"/>
 
-<p align="center">
-  <a href="https://github.com/valinerosgordov/DailyPlanner/releases/latest"><img src="https://img.shields.io/github/v/release/valinerosgordov/DailyPlanner?style=flat-square&label=latest"/></a>
-  <a href="https://github.com/valinerosgordov/DailyPlanner/releases/latest/download/DailyPlanner-win-Setup.exe"><img src="https://img.shields.io/github/downloads/valinerosgordov/DailyPlanner/total?style=flat-square&label=downloads"/></a>
-  <img src="https://img.shields.io/badge/platform-Windows%2010%2F11-blue?style=flat-square"/>
-  <img src="https://img.shields.io/badge/.NET-10-512BD4?style=flat-square&logo=.net"/>
-</p>
+# Daily &amp; Financial Planner
+
+**Weekly planner for Windows. Fully offline. Auto-updating.**
+
+Tasks · Habits · Pomodoro · Finance tracker · Trello inbox
+
+[![Latest release](https://img.shields.io/github/v/release/valinerosgordov/DailyPlanner?style=for-the-badge&color=7C3AED)](https://github.com/valinerosgordov/DailyPlanner/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/valinerosgordov/DailyPlanner/total?style=for-the-badge&color=10B981)](https://github.com/valinerosgordov/DailyPlanner/releases/latest)
+[![Platform](https://img.shields.io/badge/Windows-10%20%7C%2011-0078D4?style=for-the-badge&logo=windows)](https://github.com/valinerosgordov/DailyPlanner/releases/latest)
+[![.NET](https://img.shields.io/badge/.NET-10-512BD4?style=for-the-badge&logo=.net)](https://dotnet.microsoft.com/)
+[![License](https://img.shields.io/github/license/valinerosgordov/DailyPlanner?style=for-the-badge&color=F59E0B)](LICENSE)
+
+</div>
 
 ---
 
-## Install
+## Download
 
-**Installer (auto-updating):**
-[DailyPlanner-win-Setup.exe](https://github.com/valinerosgordov/DailyPlanner/releases/latest/download/DailyPlanner-win-Setup.exe)
+<table>
+<tr>
+<td align="center" width="50%">
 
-**Portable:**
-[DailyPlanner-win-Portable.zip](https://github.com/valinerosgordov/DailyPlanner/releases/latest/download/DailyPlanner-win-Portable.zip)
+### Installer *(recommended)*
+Auto-updates via Velopack
 
-Windows 10/11 x64. .NET 10 runtime is bundled in the self-contained build.
+**[⬇ DailyPlanner-win-Setup.exe](https://github.com/valinerosgordov/DailyPlanner/releases/latest/download/DailyPlanner-win-Setup.exe)**
+
+</td>
+<td align="center" width="50%">
+
+### Portable
+No installation, no auto-updates
+
+**[⬇ DailyPlanner-win-Portable.zip](https://github.com/valinerosgordov/DailyPlanner/releases/latest/download/DailyPlanner-win-Portable.zip)**
+
+</td>
+</tr>
+</table>
+
+Windows 10 / 11 x64. .NET 10 runtime is bundled (self-contained build).
 
 ---
 
 ## Features
 
 ### Planning
-- Weekly board with 7 day columns, 10 task slots per day
-- Subtasks, priorities (None/Low/Med/High), categories, deadlines
-- Carry-over incomplete tasks to the next day
-- Drag &amp; drop tasks between days
+- Weekly board — 7 day columns, 10 task slots per day
+- Subtasks, priorities (None / Low / Med / High), categories, deadlines
+- Drag &amp; drop between days · carry-over of incomplete tasks
 - Weekly goals, notes, reminders, meetings
-- Daily state tracking (sleep / energy / mood, 1–5 stars)
+- Daily state tracking — sleep, energy, mood (1–5 stars)
 - Habit heatmap for the last 30 days
 
-### Trello integration (Inbox)
-- Inbox sidebar built into the week view
-- Pull cards from a named list (default: “В работе”) across all your boards
-- Drag Trello cards directly onto any day — fills the first empty slot
-- Already-placed cards aren’t re-added on re-sync
+### Trello inbox
+- Built-in sidebar with cards from a named Trello list (default: *"В работе"*)
+- Pulls cards across all your boards
+- Drag a card onto any day — fills the first empty slot
+- Already-placed cards never re-appear on resync *(deduplicated by card id)*
 - Optional auto-sync on startup
 
-### Finance module
-- Income &amp; expenses with categories, budgets, and monthly analytics
+### Finance
+- Income &amp; expenses with categories, budgets, monthly analytics
 - Debts (I owe / owed to me) factored into Net Worth
-- Recurring payments (weekly / biweekly / monthly / quarterly / yearly) normalised to monthly obligatory
+- Recurring payments (weekly / biweekly / monthly / quarterly / yearly), normalised to monthly obligatory
 - Multiple accounts with transfers
 - 30-day cashflow forecast
 - Income sources with per-project payment schedule
 - Excel export
 
 ### Pomodoro
-- Work / break / focus with configurable durations
+- Work / break / focus timer with configurable durations
 - Session counter per day
 
 ### Statistics
-- Monthly task completion, productivity trends
-- Best / hardest day, goals reached
+- Monthly task completion &amp; productivity trends
+- Best / hardest day of the week, goals reached
 - Habit streak tracking
 
 ### System
-- Multi-language UI: 🇷🇺 🇺🇸 🇪🇸 🇫🇷
-- 2 themes: Pure Monochrome Dark (default, Mica backdrop) / Pure Monochrome Light
+- Single-instance guard — second launch just activates the existing window *(even from tray)*
+- Multi-language UI — 🇷🇺 🇺🇸 🇪🇸 🇫🇷
+- Pure Monochrome Dark *(default, Mica backdrop)* / Pure Monochrome Light
 - Auto-backup on startup (rolling 5)
-- Auto-updates via Velopack
-
----
-
-## Stack
-
-| Layer | Tech |
-|---|---|
-| UI | WPF + WPF-UI (FluentWindow, Mica) |
-| MVVM | CommunityToolkit.Mvvm source generators |
-| DI | Microsoft.Extensions.DependencyInjection |
-| DB | EF Core 10 + SQLite (`%LOCALAPPDATA%\DailyPlanner\planner.db`) |
-| Excel | ClosedXML |
-| Auto-update | Velopack + GitHub Releases |
-| Logging | File logger with rotation (`app.log`) |
-| Tests | xUnit + FluentAssertions |
+- Auto-updates via Velopack + GitHub Releases
 
 ---
 
@@ -102,12 +103,29 @@ Windows 10/11 x64. .NET 10 runtime is bundled in the self-contained build.
 
 ---
 
+## Stack
+
+| Layer | Tech |
+|---|---|
+| UI | WPF + [WPF-UI](https://github.com/lepoco/wpfui) (FluentWindow, Mica backdrop) |
+| MVVM | [CommunityToolkit.Mvvm](https://learn.microsoft.com/dotnet/communitytoolkit/mvvm/) (source generators) |
+| DI | `Microsoft.Extensions.DependencyInjection` |
+| DB | EF Core 10 + SQLite (`%LOCALAPPDATA%\DailyPlanner\planner.db`) |
+| Excel | [ClosedXML](https://github.com/ClosedXML/ClosedXML) |
+| Auto-update | [Velopack](https://velopack.io/) + GitHub Releases |
+| Logging | File logger with rotation (`app.log`) |
+| Tests | xUnit + FluentAssertions (74 tests, integration + unit) |
+
+---
+
 ## Build from source
 
+Requires [.NET 10 SDK Preview](https://dotnet.microsoft.com/download/dotnet/10.0).
+
 ```powershell
-# Requires .NET 10 SDK (preview)
+dotnet restore DailyPlanner.Tests/DailyPlanner.Tests.csproj
 dotnet restore DailyPlanner/DailyPlanner.csproj -r win-x64
-dotnet build   DailyPlanner/DailyPlanner.csproj --no-restore -c Release -r win-x64
+dotnet build DailyPlanner/DailyPlanner.csproj --no-restore -c Release -r win-x64
 dotnet run --project DailyPlanner
 ```
 
@@ -117,7 +135,7 @@ Run tests:
 dotnet test DailyPlanner.Tests/DailyPlanner.Tests.csproj
 ```
 
-Publish a release build:
+Publish a self-contained build:
 
 ```powershell
 dotnet publish DailyPlanner/DailyPlanner.csproj -c Release -r win-x64 --self-contained -o ./publish
@@ -125,6 +143,21 @@ dotnet publish DailyPlanner/DailyPlanner.csproj -c Release -r win-x64 --self-con
 
 ---
 
+## Data &amp; privacy
+
+All data is stored locally in `%LOCALAPPDATA%\DailyPlanner\planner.db`. The app only talks to the network when:
+
+- You enable Trello sync (requests to `api.trello.com` with *your* key + token)
+- Checking for updates (`github.com/valinerosgordov/DailyPlanner` releases)
+
+Nothing is uploaded. Nothing is telemetered. No accounts required.
+
+---
+
+## Contributing
+
+Pull requests welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Security reports: [SECURITY.md](SECURITY.md).
+
 ## License
 
-MIT
+[MIT](LICENSE) © Valiner Osgordov


### PR DESCRIPTION
## Fix — Trello cards reappearing after sync

**Before:** после распределения Trello-карточек по дням и повторного нажатия *Синхронизировать Trello* карточки снова появлялись в Inbox-колонке. Старая дедупликация держалась только на заархивированных Inbox-строках — если эти строки терялись (сброс/очистка БД), карточки добавлялись заново.

**Now:** card id сохраняется ещё и на самой `DailyTask.ExternalId`. `SyncTrelloAsync` собирает existingSet из двух источников — inbox + daily tasks.

## Changes

- `DailyTask.ExternalId` (nullable, indexed, max 100) — новое поле
- Migration `AddDailyTaskExternalId` — колонка + индекс
- `MoveInboxToDayAsync` — записывает `ExternalId` на целевую `DailyTask` для Trello-источника
- `SyncTrelloAsync` — existingSet = inbox external ids ∪ daily task external ids

## README redesign

- Центрированный hero с иконкой + бейджи
- Таблица загрузки Installer / Portable
- Сгруппированные фичи (Planning / Trello / Finance / Pomodoro / Stats / System)
- Stack table со ссылками на библиотеки
- Build-инструкции выровнены с CI (restore tests first, затем main -r win-x64)
- Privacy note: что уходит в сеть, что нет

## Test plan
- [x] `dotnet build` — OK
- [x] `dotnet test` — 74/74 passed
- [ ] Sync → Move to day → повторный Sync → карточка не возвращается
- [ ] Sync → Move to day → archive Inbox → Sync → карточка не возвращается (regression guard)