### PR TITLE
v3.24.0: Bug fixes pack (8 fixes — security, EF, lifecycle)

### DIFF
--- a/DailyPlanner.Tests/DailyPlanner.Tests.csproj
+++ b/DailyPlanner.Tests/DailyPlanner.Tests.csproj
@@ -11,10 +11,13 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <ProjectReference Include="..\DailyPlanner\DailyPlanner.csproj" />
   </ItemGroup>
 

--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -38,6 +38,10 @@ public partial class App : Application
 
         base.OnStartup(e);
 
+        Window? splash = null;
+        try
+        {
+
         VelopackApp.Build().Run();
 
         ServiceHost.Configure();
@@ -47,7 +51,7 @@ public partial class App : Application
 
         SingleInstanceGuard.StartActivationListener(ActivateMainWindow);
 
-        var splash = new Window
+        splash = new Window
         {
             Width = 380,
             Height = 220,
@@ -154,6 +158,17 @@ public partial class App : Application
         }
 
         splash.Close();
+        }
+        catch (Exception ex)
+        {
+            Log.Error("App", $"Startup failed: {ex}");
+            try { splash?.Close(); } catch { }
+            System.Windows.MessageBox.Show(
+                $"Startup failed:\n{ex.Message}",
+                "Daily & Financial Planner",
+                MessageBoxButton.OK, MessageBoxImage.Error);
+            Shutdown(1);
+        }
     }
 
     private void ActivateMainWindow()

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.23.1</Version>
+    <Version>3.24.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>
@@ -25,14 +25,14 @@
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />
-    <PackageReference Include="WPF-UI" Version="4.2.0" />
+    <PackageReference Include="WPF-UI" Version="4.2.1" />
   </ItemGroup>
 
 </Project>

--- a/DailyPlanner/Services/DebounceService.cs
+++ b/DailyPlanner/Services/DebounceService.cs
@@ -1,5 +1,5 @@
 using System.Collections.Concurrent;
-using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
 
 namespace DailyPlanner.Services;
 
@@ -28,10 +28,11 @@ public static class DebounceService
             await Task.Delay(delayMs, ct);
             await action();
         }
-        catch (TaskCanceledException)
-        {
-            // Debounced — expected
-        }
+        catch (TaskCanceledException) { }
+        catch (OperationCanceledException) { }
+        // Row was deleted or moved between debounce schedule and save —
+        // expected when user spam-edits then deletes a task.
+        catch (DbUpdateConcurrencyException) { }
         catch (Exception ex)
         {
             Log.Error("DebounceService", $"Error in '{key}': {ex.Message}");

--- a/DailyPlanner/Services/PlannerService.Debt.cs
+++ b/DailyPlanner/Services/PlannerService.Debt.cs
@@ -16,16 +16,16 @@ public sealed partial class PlannerService
     public async Task SaveDebtAsync(Debt debt, CancellationToken ct = default)
     {
         await using var db = PlannerDbContextFactory.Create();
-        var savedPayments = debt.Payments;
-        debt.Payments = [];
-
         if (debt.Id == 0)
+        {
             db.Debts.Add(debt);
+        }
         else
-            db.Debts.Update(debt);
+        {
+            db.Debts.Attach(debt);
+            db.Entry(debt).State = EntityState.Modified;
+        }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        debt.Payments = savedPayments;
     }
     public async Task RemoveDebtAsync(int debtId, CancellationToken ct = default)
     {

--- a/DailyPlanner/Services/PlannerService.Finance.cs
+++ b/DailyPlanner/Services/PlannerService.Finance.cs
@@ -116,30 +116,26 @@ public sealed partial class PlannerService
     {
         await using var db = PlannerDbContextFactory.Create();
 
-        // Prevent entries on archived categories
         if (entry.CategoryId > 0)
         {
-            var cat = await db.FinanceCategories.FindAsync([entry.CategoryId], ct).ConfigureAwait(false);
-            if (cat is { IsArchived: true }) return;
+            var isArchived = await db.FinanceCategories
+                .AsNoTracking()
+                .Where(c => c.Id == entry.CategoryId)
+                .Select(c => (bool?)c.IsArchived)
+                .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+            if (isArchived == true) return;
         }
 
-        // Detach navigation properties to avoid tracking conflicts
-        var savedCategory = entry.Category;
-        var savedWeek = entry.Week;
-        var savedRecurring = entry.RecurringPayment;
-        entry.Category = null;
-        entry.Week = null;
-        entry.RecurringPayment = null;
-
         if (entry.Id == 0)
+        {
             db.FinanceEntries.Add(entry);
+        }
         else
-            db.FinanceEntries.Update(entry);
+        {
+            db.FinanceEntries.Attach(entry);
+            db.Entry(entry).State = EntityState.Modified;
+        }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        entry.Category = savedCategory;
-        entry.Week = savedWeek;
-        entry.RecurringPayment = savedRecurring;
     }
     public async Task RemoveFinanceEntryAsync(int entryId, CancellationToken ct = default)
     {
@@ -155,16 +151,16 @@ public sealed partial class PlannerService
     public async Task SaveBudgetAsync(FinanceBudget budget, CancellationToken ct = default)
     {
         await using var db = PlannerDbContextFactory.Create();
-        var savedCategory = budget.Category;
-        budget.Category = null;
-
         if (budget.Id == 0)
+        {
             db.FinanceBudgets.Add(budget);
+        }
         else
-            db.FinanceBudgets.Update(budget);
+        {
+            db.FinanceBudgets.Attach(budget);
+            db.Entry(budget).State = EntityState.Modified;
+        }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        budget.Category = savedCategory;
     }
     public async Task RemoveBudgetAsync(int budgetId, CancellationToken ct = default)
     {
@@ -182,19 +178,16 @@ public sealed partial class PlannerService
     public async Task SaveRecurringPaymentAsync(RecurringPayment payment, CancellationToken ct = default)
     {
         await using var db = PlannerDbContextFactory.Create();
-        var savedCategory = payment.Category;
-        var savedEntries = payment.GeneratedEntries;
-        payment.Category = null;
-        payment.GeneratedEntries = [];
-
         if (payment.Id == 0)
+        {
             db.RecurringPayments.Add(payment);
+        }
         else
-            db.RecurringPayments.Update(payment);
+        {
+            db.RecurringPayments.Attach(payment);
+            db.Entry(payment).State = EntityState.Modified;
+        }
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        payment.Category = savedCategory;
-        payment.GeneratedEntries = savedEntries;
     }
     public async Task RemoveRecurringPaymentAsync(int paymentId, CancellationToken ct = default)
     {

--- a/DailyPlanner/Services/PlannerService.Inbox.cs
+++ b/DailyPlanner/Services/PlannerService.Inbox.cs
@@ -113,15 +113,18 @@ public sealed partial class PlannerService
             db.TrelloSettings.Add(settings);
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
+        settings.ApiKey = ProtectedTokenStore.Unprotect(settings.ApiKey);
         settings.Token = ProtectedTokenStore.Unprotect(settings.Token);
         return settings;
     }
     public async Task SaveTrelloSettingsAsync(TrelloSettings settings, CancellationToken ct = default)
     {
+        settings.ApiKey = ProtectedTokenStore.Protect(settings.ApiKey);
         settings.Token = ProtectedTokenStore.Protect(settings.Token);
         await using var db = PlannerDbContextFactory.Create();
         db.TrelloSettings.Update(settings);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        settings.ApiKey = ProtectedTokenStore.Unprotect(settings.ApiKey);
         settings.Token = ProtectedTokenStore.Unprotect(settings.Token);
     }
     private static readonly SemaphoreSlim _trelloSyncGate = new(1, 1);
@@ -169,9 +172,15 @@ public sealed partial class PlannerService
             added++;
         }
 
-        settings.LastSyncUtc = DateTime.UtcNow;
-        db.TrelloSettings.Update(settings);
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        // Only touch LastSyncUtc — settings.Token/ApiKey are decrypted in memory
+        // here, so a full Update(settings) would persist them as plaintext and
+        // undo the at-rest encryption from SaveTrelloSettingsAsync.
+        var tracked = await db.TrelloSettings.FirstOrDefaultAsync(s => s.Id == settings.Id, ct).ConfigureAwait(false);
+        if (tracked is not null)
+        {
+            tracked.LastSyncUtc = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
         return added;
         }
         finally { _trelloSyncGate.Release(); }

--- a/DailyPlanner/Services/PlannerService.cs
+++ b/DailyPlanner/Services/PlannerService.cs
@@ -53,7 +53,6 @@ public sealed partial class PlannerService
             week.Days.Add(day);
         }
 
-        // Copy habit names from previous week, or create empty ones
         var prevWeek = await db.Weeks
             .Include(w => w.Habits)
             .Where(w => w.StartDate < startDate)
@@ -65,7 +64,10 @@ public sealed partial class PlannerService
             .OrderBy(h => h.Order)
             .ToList() ?? [];
 
-        var habitCount = Math.Max(prevHabits.Count, 5);
+        // Brand-new install seeds 5 empty slots; any subsequent week mirrors
+        // exactly what the user keeps from the previous week — deleted habits
+        // must stay deleted.
+        var habitCount = prevWeek is null ? 5 : prevHabits.Count;
         for (var i = 1; i <= habitCount; i++)
         {
             var habit = new HabitDefinition

--- a/DailyPlanner/ViewModels/WeekViewModel.cs
+++ b/DailyPlanner/ViewModels/WeekViewModel.cs
@@ -215,6 +215,7 @@ public sealed partial class WeekViewModel : ObservableObject
     private void RefreshAnalytics()
     {
         _analyticsDebounce?.Cancel();
+        _analyticsDebounce?.Dispose();
         _analyticsDebounce = new CancellationTokenSource();
         var token = _analyticsDebounce.Token;
 


### PR DESCRIPTION
8 фиксов в одном PR — приоритет 1 + 2 из аудита + регрессия v3.23.0 + bumps.

## Critical
1. **Trello sync writes plaintext token (regression v3.23.0).** \`GetTrelloSettingsAsync\` расшифровывает токен в памяти, потом \`SyncTrelloAsync\` делал \`Update(settings)\` и записывал расшифрованное обратно в SQLite. Заменено на загрузку tracked-сущности и точечный апдейт \`LastSyncUtc\`. Шифрованные \`Token\`/\`ApiKey\` на диске остаются нетронутыми.
2. **ApiKey тоже шифруется DPAPI** (раньше только \`Token\`).

## High
3. **DebounceService глотает \`DbUpdateConcurrencyException\`.** Эти ошибки нормальны — debounced save ловит уже удалённую/перенесённую запись. Раньше каждая такая ситуация засоряла \`app.log\` Error-строкой.
4. **Finance/Debt Save** — заменил паттерн \"занули nav-property → save → восстанови\" на \`Attach + Entry().State = Modified\`. Решает FinanceCategory tracking conflict (был в логах) и убирает UI-race, когда биндинги видели \`entry.Category = null\` посреди save. Archive-check вынесен в \`AsNoTracking\` запрос.
5. **Habit seeding на новой неделе** теперь mirror'ит предыдущую неделю. Раньше \`Math.Max(prevHabits.Count, 5)\` всегда возвращал ≥5 → удалённые пользователем habits возвращались пустыми слотами.
6. **App.OnStartup top-level try/catch.** Раньше сбой в \`ThemeService.Apply()\`/\`ServiceHost.Configure()\`/Velopack/Window-creation оставлял splash висеть навеки. Теперь — splash закрывается, MessageBox с ошибкой, \`Shutdown(1)\`.
7. **WeekViewModel.RefreshAnalytics** диспозит предыдущий \`CancellationTokenSource\` перед созданием нового. Kernel-handle leak на каждом изменении state/goal.

## Packages
- Microsoft.EntityFrameworkCore.Design 10.0.6 → **10.0.7**
- Microsoft.EntityFrameworkCore.Sqlite 10.0.6 → **10.0.7**
- Microsoft.Extensions.DependencyInjection 10.0.6 → **10.0.7**
- WPF-UI 4.2.0 → **4.2.1**
- Microsoft.Data.Sqlite 10.0.6 → **10.0.7**
- Microsoft.NET.Test.Sdk 17.14.1 → **18.5.1**
- xunit.runner.visualstudio 3.1.4 → **3.1.5**

FluentAssertions 7→8 не обновлял (8.x — коммерческая лицензия для commercial use).
coverlet.collector 6→10 не обновлял (major bump, отдельным PR с coverage CI).

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test\` — 74/74 passed
- [x] Smoke run: log delta = **+0 lines**, **0 errors** (было до 5,592 на запуск в v3.23.0)
- [ ] Сохранить Trello settings → перезапуск → токен расшифровывается, sync работает (без plaintext в БД)
- [ ] Удалить пару habits → следующая неделя → habits не возвращаются