### PR TITLE
v3.28.0: Typography expansion — sidebar / habit table / page header

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.27.0</Version>
+    <Version>3.28.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/MainWindow.xaml
+++ b/DailyPlanner/MainWindow.xaml
@@ -77,8 +77,7 @@
                             <Run Text=" Planner" Foreground="{DynamicResource TextPrimaryBrush}"/>
                         </TextBlock>
                     </StackPanel>
-                    <TextBlock Text="{Binding SelectedYear}" FontSize="11"
-                               Foreground="{DynamicResource MutedBrush}" Margin="32,3,0,0"/>
+                    <TextBlock Text="{Binding SelectedYear}" Style="{StaticResource MicroLabelDim}" Margin="32,3,0,0"/>
                 </StackPanel>
 
                 <!-- Today Mini Widget -->
@@ -90,11 +89,8 @@
                         <DockPanel Margin="0,0,0,4">
                             <ui:SymbolIcon Symbol="CalendarToday24" FontSize="12"
                                            Foreground="{DynamicResource AccentBrush}" DockPanel.Dock="Left" Margin="0,0,6,0"/>
-                            <TextBlock Text="{Binding [Today], Source={x:Static svc:Loc.Instance}}" FontSize="9" FontWeight="Bold"
-                                       Foreground="{DynamicResource AccentBrush}" VerticalAlignment="Center"/>
-                            <TextBlock Text="{Binding TodayProgress}" FontSize="9"
-                                       Foreground="{DynamicResource MutedBrush}"
-                                       HorizontalAlignment="Right" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding [Today], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabelAccent}" VerticalAlignment="Center"/>
+                            <TextBlock Text="{Binding TodayProgress}" Style="{StaticResource MicroLabelDim}" HorizontalAlignment="Right" VerticalAlignment="Center"/>
                         </DockPanel>
                         <TextBlock Text="{Binding TodayTasks}" FontSize="10"
                                    TextWrapping="Wrap" Foreground="{DynamicResource TextPrimaryBrush}"
@@ -412,12 +408,9 @@
                         <RowDefinition/>
                         <RowDefinition/>
                     </Grid.RowDefinitions>
-                    <TextBlock Grid.Column="0" Text="{Binding [PomWork], Source={x:Static svc:Loc.Instance}}" FontSize="9" HorizontalAlignment="Center"
-                               Foreground="{DynamicResource MutedBrush}" Margin="0,0,0,4"/>
-                    <TextBlock Grid.Column="2" Text="{Binding [PomBreak], Source={x:Static svc:Loc.Instance}}" FontSize="9" HorizontalAlignment="Center"
-                               Foreground="{DynamicResource MutedBrush}" Margin="0,0,0,4"/>
-                    <TextBlock Grid.Column="4" Text="{Binding [PomFocus], Source={x:Static svc:Loc.Instance}}" FontSize="9" HorizontalAlignment="Center"
-                               Foreground="{DynamicResource MutedBrush}" Margin="0,0,0,4"/>
+                    <TextBlock Grid.Column="0" Text="{Binding [PomWork], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabelDim}" HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                    <TextBlock Grid.Column="2" Text="{Binding [PomBreak], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabelDim}" HorizontalAlignment="Center" Margin="0,0,0,4"/>
+                    <TextBlock Grid.Column="4" Text="{Binding [PomFocus], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabelDim}" HorizontalAlignment="Center" Margin="0,0,0,4"/>
                     <ui:NumberBox Grid.Row="1" Grid.Column="0" Value="{Binding WorkMinutes, Mode=TwoWay}"
                                   Minimum="1" Maximum="120" SpinButtonPlacementMode="Hidden"
                                   Height="36" FontSize="14" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" ClearButtonEnabled="False"/>

--- a/DailyPlanner/Views/StatisticsPage.xaml
+++ b/DailyPlanner/Views/StatisticsPage.xaml
@@ -19,9 +19,8 @@
                 <StackPanel Orientation="Horizontal" DockPanel.Dock="Left">
                     <ui:Button Icon="{ui:SymbolIcon ChevronLeft24}" Appearance="Transparent"
                                Command="{Binding PreviousMonthCommand}" Padding="8"/>
-                    <TextBlock Text="{Binding PeriodLabel}" FontSize="24" FontWeight="SemiBold"
-                               VerticalAlignment="Center" Margin="12,0"
-                               FontFamily="{StaticResource MainFont}"/>
+                    <TextBlock Text="{Binding PeriodLabel}" Style="{StaticResource HeroSerifItalic}" FontSize="26"
+                               VerticalAlignment="Center" Margin="12,0"/>
                     <ui:Button Icon="{ui:SymbolIcon ChevronRight24}" Appearance="Transparent"
                                Command="{Binding NextMonthCommand}" Padding="8"/>
                 </StackPanel>

--- a/DailyPlanner/Views/WeekPage.xaml
+++ b/DailyPlanner/Views/WeekPage.xaml
@@ -543,8 +543,7 @@
                             <StackPanel>
                                 <DockPanel Margin="0,0,0,4">
                                     <TextBlock Text="{Binding DateFormatted}" DockPanel.Dock="Right"
-                                               Foreground="{DynamicResource MutedBrush}"
-                                               FontSize="10" VerticalAlignment="Center" Margin="6,0,0,0"/>
+                                               Style="{StaticResource MicroLabelDim}" VerticalAlignment="Center" Margin="6,0,0,0"/>
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Text="{Binding DayName}" Style="{StaticResource DayHeader}" FontSize="12"/>
                                         <!-- Today badge -->
@@ -871,15 +870,15 @@
                                 <ColumnDefinition Width="28"/><ColumnDefinition Width="70"/>
                                 <ColumnDefinition Width="28"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" Text="{Binding [HabitLabel], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" Margin="4,0,0,0"/>
-                            <TextBlock Grid.Column="1" Text="{Binding [Mon], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="2" Text="{Binding [Tue], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="3" Text="{Binding [Wed], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="4" Text="{Binding [Thu], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="5" Text="{Binding [Fri], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="6" Text="{Binding [Sat], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="7" Text="{Binding [Sun], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
-                            <TextBlock Grid.Column="8" Text="{Binding [ProgressCol], Source={x:Static svc:Loc.Instance}}" Foreground="{DynamicResource MutedBrush}" FontSize="10" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="0" Text="{Binding [HabitLabel], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" Margin="4,0,0,0"/>
+                            <TextBlock Grid.Column="1" Text="{Binding [Mon], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="2" Text="{Binding [Tue], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="3" Text="{Binding [Wed], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="4" Text="{Binding [Thu], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="5" Text="{Binding [Fri], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="6" Text="{Binding [Sat], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="7" Text="{Binding [Sun], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
+                            <TextBlock Grid.Column="8" Text="{Binding [ProgressCol], Source={x:Static svc:Loc.Instance}}" Style="{StaticResource MicroLabel}" HorizontalAlignment="Center"/>
                         </Grid>
                         <!-- Empty state -->
                         <TextBlock Text="{Binding [HabitEmpty], Source={x:Static svc:Loc.Instance}}" FontSize="11"


### PR DESCRIPTION
Continuation of the opt-in typography migration started in #70. No new modules, no behavioural changes — pure XAML style swaps. All 74 tests green, dotnet format clean locally.

## What's migrated

**MainWindow (sidebar):**
-  + 'SelectedYear' +  caption →  + 'MicroLabelDim' + 
- Today widget header ( + 'СЕГОДНЯ' + ) →  + 'MicroLabelAccent' + 
-  + 'TodayProgress' +  (right-aligned ratio) →  + 'MicroLabelDim' + 
- Pomodoro Work / Break / Focus column captions →  + 'MicroLabelDim' + 

**WeekPage (habit table + day cards):**
- Habit table column headers —  + 'HabitLabel' +  + Mon/Tue/Wed/Thu/Fri/Sat/Sun +  + 'ProgressCol' +  →  + 'MicroLabel' +  (9 sites)
- Day card date caption ( + 'DateFormatted' + , top-right of each column) →  + 'MicroLabelDim' + 

**StatisticsPage (page header):**
-  + 'PeriodLabel' +  migrated to  + 'HeroSerifItalic' +   + 'FontSize=26' +  — first real use of the editorial italic hero in any page. Inter Black Italic. Kept at 26 instead of the style default 32 to fit between the chevron nav buttons.

## What's deliberately left

- Sleep / Energy / Mood labels in WeekPage day-card mood block — they use semantic  + 'Foreground' +  (Info / Warning / Success), migration would need inline overrides; saved for a follow-up.
-  + 'PeriodLabel' +  in FinancePage — same migration mechanically valid, holding off until the Statistics pilot is visually approved.
- Pomodoro  + 'ModeLabel' +  /  + 'PhaseLabel' +  (semi-bold value labels, not micro) — these are content, not chrome.

## Smoke-test risks

1.  + 'HeroSerifItalic' +  at 26 between chevrons — make sure  + 'PeriodLabel' +  doesn't bump the right chevron off-screen at 1200px MinWidth.
2. Pomodoro 9px caption upgraded to 10px Mono Black — visually larger, double-check no clipping in the narrow 3-col Pomodoro grid.
3. Habit table headers (now Mono Black 10) — verify Cyrillic / Latin / FR / ES day abbreviations all render in the JetBrains Mono variable font.

## Version bump

 + 'DailyPlanner.csproj' +  bumped 3.27.0 → 3.28.0.