### PR TITLE
v3.29.0: DB reliability — integrity-gated backups + recovery dialog

### DIFF
--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -125,17 +125,44 @@ public partial class App : Application
                         var backupDir = System.IO.Path.Combine(PlannerDbContextFactory.AppDataFolder, "backups");
                         System.IO.Directory.CreateDirectory(backupDir);
                         var backupName = $"planner_{DateTime.Now:yyyyMMdd_HHmmss}.db";
-                        System.IO.File.Copy(dbPath, System.IO.Path.Combine(backupDir, backupName), true);
+                        var backupPath = System.IO.Path.Combine(backupDir, backupName);
 
-                        var old = System.IO.Directory.GetFiles(backupDir, "planner_*.db")
-                            .OrderByDescending(f => System.IO.File.GetCreationTimeUtc(f))
-                            .Skip(5);
-                        foreach (var f in old)
-                            try { System.IO.File.Delete(f); } catch (Exception ex) { Log.Error("App", $"Backup cleanup: {ex.Message}"); }
+                        // SafeCopy refuses to back up an unhealthy DB. This protects the
+                        // retention window — without this gate every backup would just be
+                        // a copy of the same corrupted file, wiping good history.
+                        if (DbIntegrity.SafeCopy(dbPath, backupPath))
+                        {
+                            var old = System.IO.Directory.GetFiles(backupDir, "planner_*.db")
+                                .OrderByDescending(f => System.IO.File.GetCreationTimeUtc(f))
+                                .Skip(5);
+                            foreach (var f in old)
+                                try { System.IO.File.Delete(f); } catch (Exception ex) { Log.Error("App", $"Backup cleanup: {ex.Message}"); }
+                        }
+                        // else: SafeCopy already logged the reason; old healthy backups stay.
                     }
                 }
                 catch (Exception ex) { Log.Error("App", $"Backup failed: {ex.Message}"); }
             });
+
+            // Startup integrity check — catches corruption BEFORE EF tries to migrate
+            // (which would just throw a confusing 'malformed' exception every launch).
+            // If the live DB is bad, offer to recover via VACUUM INTO or fall back to
+            // the most recent healthy backup.
+            try
+            {
+                var dbPath = PlannerDbContextFactory.DbPath;
+                if (System.IO.File.Exists(dbPath) && !DbIntegrity.IsHealthy(dbPath))
+                {
+                    splash.Close();
+                    if (!await TryRecoverDatabaseInteractiveAsync(dbPath))
+                    {
+                        Shutdown(1);
+                        return;
+                    }
+                    splash = null;
+                }
+            }
+            catch (Exception ex) { Log.Error("App", $"Integrity check failed: {ex.Message}"); }
 
             try
             {
@@ -144,10 +171,15 @@ public partial class App : Application
                     using var db = PlannerDbContextFactory.Create();
                     db.Database.Migrate();
                 });
+
+                // WAL checkpoint right after migration: flushes any -wal residue into
+                // the main file so a crash window doesn't leave the on-disk image
+                // referencing log pages that may not have been fsync'd.
+                DbIntegrity.Checkpoint(PlannerDbContextFactory.DbPath);
             }
             catch (Exception ex)
             {
-                splash.Close();
+                splash?.Close();
                 System.Windows.MessageBox.Show(
                     string.Format(Loc.Get("DbError"), ex.Message),
                     "Daily & Financial Planner",
@@ -157,7 +189,7 @@ public partial class App : Application
                 return;
             }
 
-            splash.Close();
+            splash?.Close();
         }
         catch (Exception ex)
         {
@@ -171,6 +203,91 @@ public partial class App : Application
         }
     }
 
+    /// <summary>
+    /// Shown when the live DB fails PRAGMA integrity_check at startup. Offers two
+    /// non-destructive paths: in-place recovery via VACUUM INTO, or restore from the
+    /// most recent healthy backup. The corrupted file is always preserved as
+    /// .corrupt-{timestamp} alongside the live DB before any replacement.
+    /// </summary>
+    private static async Task<bool> TryRecoverDatabaseInteractiveAsync(string dbPath)
+    {
+        var backupDir = System.IO.Path.Combine(PlannerDbContextFactory.AppDataFolder, "backups");
+        var healthyBackup = DbIntegrity.FindLatestHealthyBackup(backupDir);
+
+        var msg = string.Format(Loc.Get("RecoveryMessage"),
+            healthyBackup is null ? Loc.Get("RecoveryNoBackup") : System.IO.Path.GetFileName(healthyBackup));
+
+        // Yes  = attempt VACUUM INTO recovery (preserves all live data we can salvage)
+        // No   = restore from latest healthy backup (older but guaranteed clean)
+        // Cancel = quit so the user can decide what to do manually
+        var choice = System.Windows.MessageBox.Show(
+            msg,
+            Loc.Get("RecoveryTitle"),
+            healthyBackup is null ? MessageBoxButton.YesNoCancel : MessageBoxButton.YesNoCancel,
+            MessageBoxImage.Warning,
+            MessageBoxResult.Yes);
+
+        if (choice == MessageBoxResult.Cancel) return false;
+
+        var corruptArchive = $"{dbPath}.corrupt-{DateTime.Now:yyyyMMdd-HHmmss}";
+        try { System.IO.File.Copy(dbPath, corruptArchive, true); }
+        catch (Exception ex) { Log.Error("App", $"Could not archive corrupt DB: {ex.Message}"); }
+
+        if (choice == MessageBoxResult.Yes)
+        {
+            var recovered = $"{dbPath}.recovered";
+            var ok = await Task.Run(() => DbIntegrity.TryRecover(dbPath, recovered));
+            if (!ok)
+            {
+                System.Windows.MessageBox.Show(Loc.Get("RecoveryFailed"),
+                    Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
+            }
+            try
+            {
+                System.IO.File.Delete(dbPath);
+                System.IO.File.Move(recovered, dbPath);
+                // Stale WAL/SHM from the corrupted DB must go — they reference pages
+                // that no longer exist in the recovered file.
+                foreach (var sidecar in new[] { dbPath + "-wal", dbPath + "-shm" })
+                    try { if (System.IO.File.Exists(sidecar)) System.IO.File.Delete(sidecar); } catch { }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("App", $"Recovered swap failed: {ex.Message}");
+                System.Windows.MessageBox.Show(Loc.Get("RecoveryFailed"),
+                    Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Error);
+                return false;
+            }
+            System.Windows.MessageBox.Show(Loc.Get("RecoverySuccess"),
+                Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Information);
+            return true;
+        }
+
+        // choice == No: restore from healthy backup
+        if (healthyBackup is null)
+        {
+            System.Windows.MessageBox.Show(Loc.Get("RecoveryNoBackup"),
+                Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Error);
+            return false;
+        }
+        try
+        {
+            System.IO.File.Copy(healthyBackup, dbPath, true);
+            foreach (var sidecar in new[] { dbPath + "-wal", dbPath + "-shm" })
+                try { if (System.IO.File.Exists(sidecar)) System.IO.File.Delete(sidecar); } catch { }
+        }
+        catch (Exception ex)
+        {
+            Log.Error("App", $"Backup restore failed: {ex.Message}");
+            System.Windows.MessageBox.Show(Loc.Get("RecoveryFailed"),
+                Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Error);
+            return false;
+        }
+        System.Windows.MessageBox.Show(Loc.Get("RecoverySuccess"),
+            Loc.Get("RecoveryTitle"), MessageBoxButton.OK, MessageBoxImage.Information);
+        return true;
+    }
     private void ActivateMainWindow()
     {
         if (MainWindow is null) return;

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -9,7 +9,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.28.0</Version>
+    <Version>3.29.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Services/DbIntegrity.cs
+++ b/DailyPlanner/Services/DbIntegrity.cs
@@ -1,0 +1,162 @@
+using System.IO;
+using Microsoft.Data.Sqlite;
+
+namespace DailyPlanner.Services;
+
+/// <summary>
+/// SQLite database integrity checks, safe backup gating, and lightweight recovery.
+///
+/// Why this exists: the app's auto-backup on startup was a raw <see cref="File.Copy"/>.
+/// When the live DB became corrupted, every subsequent backup was a copy of the
+/// corrupted file — the user lost all healthy backups within the retention window
+/// (last 5). This service refuses to back up unhealthy databases and offers a
+/// VACUUM INTO based recovery path.
+/// </summary>
+public static class DbIntegrity
+{
+    public const string OkResult = "ok";
+
+    /// <summary>
+    /// Runs <c>PRAGMA integrity_check</c> on a SQLite file. Returns "ok" if the
+    /// database is healthy, otherwise the first error line SQLite emitted, or a
+    /// short diagnostic if the file could not be opened at all.
+    /// </summary>
+    public static string Check(string dbPath)
+    {
+        if (string.IsNullOrWhiteSpace(dbPath)) return "missing-path";
+        if (!File.Exists(dbPath)) return "missing-file";
+
+        try
+        {
+            using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA integrity_check;";
+            var result = cmd.ExecuteScalar()?.ToString();
+            return string.IsNullOrEmpty(result) ? "no-result" : result;
+        }
+        catch (SqliteException ex)
+        {
+            return $"sqlite-error: {ex.SqliteErrorCode} {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            return $"error: {ex.Message}";
+        }
+    }
+
+    public static bool IsHealthy(string dbPath) => Check(dbPath) == OkResult;
+
+    /// <summary>
+    /// Copies <paramref name="sourcePath"/> to <paramref name="destPath"/> only when
+    /// the source passes <c>PRAGMA integrity_check</c>. If the source is unhealthy,
+    /// the copy is refused and the existing destination (if any) is left intact.
+    /// </summary>
+    /// <returns>true if the copy was performed; false otherwise.</returns>
+    public static bool SafeCopy(string sourcePath, string destPath)
+    {
+        var status = Check(sourcePath);
+        if (status != OkResult)
+        {
+            Log.Error("DbIntegrity",
+                $"Refusing backup: source DB unhealthy. status='{Truncate(status, 200)}', source='{sourcePath}'");
+            return false;
+        }
+
+        try
+        {
+            File.Copy(sourcePath, destPath, true);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error("DbIntegrity", $"SafeCopy failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to recover salvageable data from a corrupted SQLite using
+    /// <c>VACUUM INTO</c>. The new file gets only the live, navigable rows;
+    /// orphaned pages are dropped. Verifies the result with integrity_check.
+    /// </summary>
+    /// <returns>true if a healthy recovered DB was produced.</returns>
+    public static bool TryRecover(string corruptPath, string recoveredPath)
+    {
+        if (!File.Exists(corruptPath))
+        {
+            Log.Error("DbIntegrity", $"TryRecover: source missing: {corruptPath}");
+            return false;
+        }
+
+        try { if (File.Exists(recoveredPath)) File.Delete(recoveredPath); } catch { /* best-effort */ }
+
+        try
+        {
+            using var conn = new SqliteConnection($"Data Source={corruptPath};Mode=ReadOnly");
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            // VACUUM INTO does not accept parameter binding for the path literal.
+            // Path is built locally (not user input), so manual quoting is acceptable here.
+            cmd.CommandText = $"VACUUM INTO '{recoveredPath.Replace("'", "''")}';";
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Log.Error("DbIntegrity", $"VACUUM INTO failed: {ex.Message}");
+            return false;
+        }
+
+        var status = Check(recoveredPath);
+        if (status != OkResult)
+        {
+            Log.Error("DbIntegrity", $"Recovered DB still unhealthy: {Truncate(status, 200)}");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Forces a WAL checkpoint to flush the write-ahead log into the main DB file.
+    /// Reduces the window in which a crash can leave the WAL desynced from main.
+    /// </summary>
+    public static void Checkpoint(string dbPath)
+    {
+        if (!File.Exists(dbPath)) return;
+        try
+        {
+            using var conn = new SqliteConnection($"Data Source={dbPath}");
+            conn.Open();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Log.Error("DbIntegrity", $"Checkpoint failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Returns the most recent backup whose integrity_check passes, scanning
+    /// <c>planner_*.db</c> files in <paramref name="backupDir"/> from newest to
+    /// oldest. Returns null if no healthy backup exists.
+    /// </summary>
+    public static string? FindLatestHealthyBackup(string backupDir)
+    {
+        if (!Directory.Exists(backupDir)) return null;
+
+        var candidates = Directory.GetFiles(backupDir, "planner_*.db")
+            .OrderByDescending(File.GetCreationTimeUtc);
+
+        foreach (var path in candidates)
+        {
+            if (IsHealthy(path)) return path;
+        }
+        return null;
+    }
+
+    private static string Truncate(string s, int max) =>
+        string.IsNullOrEmpty(s) ? string.Empty : (s.Length <= max ? s : s.Substring(0, max) + "...");
+}

--- a/DailyPlanner/Services/Loc.En.cs
+++ b/DailyPlanner/Services/Loc.En.cs
@@ -1,4 +1,4 @@
-﻿namespace DailyPlanner.Services;
+namespace DailyPlanner.Services;
 
 internal static class LocEnStrings
 {
@@ -480,6 +480,11 @@ internal static class LocEnStrings
         ["CmdPreviousMonth"] = "Previous month",
         ["CmdNextMonth"] = "Next month",
         ["CmdBackupDb"] = "Backup database",
+        ["RecoveryTitle"] = "Database integrity check failed",
+        ["RecoveryMessage"] = "The application's data file appears to be corrupted. Available options:\n\n• Yes — automatic recovery (VACUUM INTO, preserves all readable rows)\n• No — roll back to the latest healthy backup: {0}\n• Cancel — quit so you can resolve manually\n\nThe corrupted file will be archived alongside as .corrupt-{{timestamp}} either way.",
+        ["RecoverySuccess"] = "Database successfully recovered. Please restart the app.",
+        ["RecoveryFailed"] = "Recovery failed. See app.log for details.",
+        ["RecoveryNoBackup"] = "(no healthy backup found)",
         ["CmdRestoreDb"] = "Restore database",
     };
 }

--- a/DailyPlanner/Services/Loc.Es.cs
+++ b/DailyPlanner/Services/Loc.Es.cs
@@ -1,4 +1,4 @@
-﻿namespace DailyPlanner.Services;
+namespace DailyPlanner.Services;
 
 internal static class LocEsStrings
 {
@@ -480,6 +480,11 @@ internal static class LocEsStrings
         ["CmdPreviousMonth"] = "Mes anterior",
         ["CmdNextMonth"] = "Mes siguiente",
         ["CmdBackupDb"] = "Copia de seguridad",
+        ["RecoveryTitle"] = "Verificación de integridad de BD fallida",
+        ["RecoveryMessage"] = "El archivo de datos parece estar corrupto. Opciones disponibles:\n\n• Sí — recuperación automática (VACUUM INTO, conserva todas las filas legibles)\n• No — revertir a la copia de seguridad sana más reciente: {0}\n• Cancelar — salir para resolverlo manualmente\n\nEl archivo dañado se conservará como .corrupt-{{marca}} en cualquier caso.",
+        ["RecoverySuccess"] = "BD recuperada correctamente. Reinicia la aplicación.",
+        ["RecoveryFailed"] = "Recuperación fallida. Consulta app.log.",
+        ["RecoveryNoBackup"] = "(sin copia sana disponible)",
         ["CmdRestoreDb"] = "Restaurar BD",
     };
 }

--- a/DailyPlanner/Services/Loc.Fr.cs
+++ b/DailyPlanner/Services/Loc.Fr.cs
@@ -1,4 +1,4 @@
-﻿namespace DailyPlanner.Services;
+namespace DailyPlanner.Services;
 
 internal static class LocFrStrings
 {
@@ -480,6 +480,11 @@ internal static class LocFrStrings
         ["CmdPreviousMonth"] = "Mois précédent",
         ["CmdNextMonth"] = "Mois suivant",
         ["CmdBackupDb"] = "Sauvegarder la BD",
+        ["RecoveryTitle"] = "Vérification d'intégrité de la BD échouée",
+        ["RecoveryMessage"] = "Le fichier de données de l'application semble corrompu. Options disponibles :\n\n• Oui — récupération automatique (VACUUM INTO, conserve toutes les lignes lisibles)\n• Non — revenir à la dernière sauvegarde saine : {0}\n• Annuler — quitter pour résoudre manuellement\n\nLe fichier corrompu sera archivé en tant que .corrupt-{{horodatage}} dans tous les cas.",
+        ["RecoverySuccess"] = "BD récupérée avec succès. Redémarrez l'application.",
+        ["RecoveryFailed"] = "Échec de la récupération. Voir app.log.",
+        ["RecoveryNoBackup"] = "(aucune sauvegarde saine trouvée)",
         ["CmdRestoreDb"] = "Restaurer la BD",
     };
 }

--- a/DailyPlanner/Services/Loc.Ru.cs
+++ b/DailyPlanner/Services/Loc.Ru.cs
@@ -1,4 +1,4 @@
-﻿namespace DailyPlanner.Services;
+namespace DailyPlanner.Services;
 
 internal static class LocRuStrings
 {
@@ -513,6 +513,11 @@ internal static class LocRuStrings
         ["CmdPreviousMonth"] = "Предыдущий месяц",
         ["CmdNextMonth"] = "Следующий месяц",
         ["CmdBackupDb"] = "Резервная копия БД",
+        ["RecoveryTitle"] = "Целостность БД нарушена",
+        ["RecoveryMessage"] = "Файл данных приложения повреждён. Доступные варианты:\n\n• Да — автоматическое восстановление (VACUUM INTO, сохраняет все читаемые записи)\n• Нет — откатиться к последней здоровой резервной копии: {0}\n• Отмена — выйти, чтобы решить вручную\n\nПовреждённый файл будет сохранён рядом как .corrupt-{{дата}} в любом случае.",
+        ["RecoverySuccess"] = "БД успешно восстановлена. Перезапустите приложение.",
+        ["RecoveryFailed"] = "Восстановление не удалось. Подробности в app.log.",
+        ["RecoveryNoBackup"] = "(нет здоровой копии)",
         ["CmdRestoreDb"] = "Восстановить БД",
     };
 }


### PR DESCRIPTION
## Why now
On 2026-05-09 the live planner.db was corrupted. App.log showed 87 'database disk image is malformed' errors going back four days; the live DB and **all 5 retained backups** were corrupt — the auto-backup loop had been faithfully File.Copy'ing the malformed file over good history. SQLite VACUUM INTO recovered 100% of the recent data; the only healthy backup left was three weeks old.

This PR ensures that exact failure mode can't happen again.

## Changes

**Services/DbIntegrity.cs** (new) — central place for SQLite health operations:
*  + 'Check' +  /  + 'IsHealthy' +  — wraps PRAGMA integrity_check
*  + 'SafeCopy' +  — copies only when source passes integrity check
*  + 'TryRecover' +  — VACUUM INTO based salvage with verification
*  + 'Checkpoint' +  — wal_checkpoint(TRUNCATE) to shrink crash window
*  + 'FindLatestHealthyBackup' +  — scans newest-first, returns first healthy

**App.xaml.cs**:
* Auto-backup uses SafeCopy → refuses to overwrite history with corruption
* Startup integrity check before EF Migrate → recovery dialog instead of cryptic crash
* WAL checkpoint after Migrate
* Corrupted file archived as  + '.corrupt-{timestamp}' +  before any replacement
* Stale -wal/-shm sidecars deleted after swap

**Loc.{Ru,En,Es,Fr}.cs** — 5 new keys for the recovery dialog.

## Tests
74 tests pass, dotnet format clean.

## Smoke risks
- Recovery MessageBox is modal on UI thread; if a user dismisses with a hot WAL still attached, the WAL/SHM cleanup might race with EF re-opening the connection. Mitigated by Shutdown(1) on Cancel and explicit sidecar deletion on Yes/No paths.
- VACUUM INTO can fail on very deep corruption (b-tree unwalkable). The flow falls through to backup-restore in that case via the dialog's No path.

## After merge
- Next:  + 'chore/security-debt' +  (Trello token plaintext, URL params -> Authorization, ApiKey encryption, ProtectedTokenStore fail-fast)
- Then:  + 'chore/quality-debt-and-design-fixes' +  (Test SDK, FluentAssertions -> Shouldly, MicroLabel uppercase, Excel formula prefix, LibraryImport, FinanceCalculations, EnsureCreated -> Migrate in tests)