### PR TITLE
v3.31.0: Quality + design — Excel injection, P/Invoke, finance constants, micro-label

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -7,11 +7,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.30.0</Version>
+    <Version>3.31.0</Version>
     <Authors>DailyPlanner Team</Authors>
-    <Description>Daily &amp; Financial Planner — weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
+    <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/DailyPlanner/Services/ExportService.cs
+++ b/DailyPlanner/Services/ExportService.cs
@@ -7,6 +7,23 @@ namespace DailyPlanner.Services;
 
 public static class ExportService
 {
+    /// <summary>
+    /// Prefixes a leading apostrophe to strings that Excel would otherwise
+    /// interpret as a formula (=, +, -, @, tab, CR). Without this guard, a
+    /// malicious task name like <c>=cmd|'/c calc.exe'!A1</c> would execute when
+    /// the exported XLSX is opened in Excel.
+    /// </summary>
+    private static string EscapeForExcel(string? s)
+    {
+        if (string.IsNullOrEmpty(s)) return s ?? string.Empty;
+        var first = s[0];
+        return first switch
+        {
+            '=' or '+' or '-' or '@' or '\t' or '\r' => "'" + s,
+            _ => s
+        };
+    }
+
     public static bool ExportWeekToExcel(PlannerWeek week, string filePath)
     {
         try
@@ -28,7 +45,7 @@ public static class ExportService
             foreach (var goal in week.Goals.OrderBy(g => g.Order))
             {
                 ws.Cell(row, 1).Value = goal.Order;
-                ws.Cell(row, 2).Value = goal.Text;
+                ws.Cell(row, 2).Value = EscapeForExcel(goal.Text);
                 ws.Cell(row, 3).Value = goal.IsCompleted ? "\u2713" : "";
                 row++;
             }
@@ -60,7 +77,7 @@ public static class ExportService
                         var prefix = task.ParentTaskId is not null ? "  └ " : "";
                         var text = $"{prefix}{task.Text}";
                         if (task.IsCompleted) text = $"\u2713 {text}";
-                        ws.Cell(row, d + 2).Value = text;
+                        ws.Cell(row, d + 2).Value = EscapeForExcel(text);
                     }
                 }
                 row++;
@@ -99,7 +116,7 @@ public static class ExportService
 
             foreach (var habit in week.Habits.OrderBy(h => h.Order))
             {
-                ws.Cell(row, 1).Value = habit.Name;
+                ws.Cell(row, 1).Value = EscapeForExcel(habit.Name);
                 var ordered = new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday,
                 DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday };
                 var entryMap = habit.Entries.ToDictionary(e => e.DayOfWeek);
@@ -121,14 +138,14 @@ public static class ExportService
             {
                 foreach (var note in week.WeeklyNotes.OrderBy(n => n.Order))
                 {
-                    ws.Cell(row, 1).Value = note.Text;
+                    ws.Cell(row, 1).Value = EscapeForExcel(note.Text);
                     ws.Range(row, 1, row, 8).Merge();
                     row++;
                 }
             }
             if (!string.IsNullOrWhiteSpace(week.Notes))
             {
-                ws.Cell(row, 1).Value = week.Notes;
+                ws.Cell(row, 1).Value = EscapeForExcel(week.Notes);
                 ws.Range(row, 1, row, 8).Merge();
             }
 
@@ -188,8 +205,8 @@ public static class ExportService
 
             foreach (var e in income)
             {
-                ws.Cell(row, 1).Value = $"{e.CategoryIcon} {e.CategoryName}";
-                ws.Cell(row, 2).Value = e.Description;
+                ws.Cell(row, 1).Value = EscapeForExcel($"{e.CategoryIcon} {e.CategoryName}");
+                ws.Cell(row, 2).Value = EscapeForExcel(e.Description);
                 ws.Cell(row, 3).Value = e.Amount;
                 ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
                 ws.Cell(row, 4).Value = e.DisplayDate;
@@ -210,8 +227,8 @@ public static class ExportService
 
             foreach (var e in expenses)
             {
-                ws.Cell(row, 1).Value = $"{e.CategoryIcon} {e.CategoryName}";
-                ws.Cell(row, 2).Value = e.Description;
+                ws.Cell(row, 1).Value = EscapeForExcel($"{e.CategoryIcon} {e.CategoryName}");
+                ws.Cell(row, 2).Value = EscapeForExcel(e.Description);
                 ws.Cell(row, 3).Value = e.Amount;
                 ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
                 ws.Cell(row, 4).Value = e.DisplayDate;
@@ -234,7 +251,7 @@ public static class ExportService
 
                 foreach (var b in budgets)
                 {
-                    ws.Cell(row, 1).Value = $"{b.CategoryIcon} {b.CategoryName}";
+                    ws.Cell(row, 1).Value = EscapeForExcel($"{b.CategoryIcon} {b.CategoryName}");
                     ws.Cell(row, 2).Value = b.Amount;
                     ws.Cell(row, 2).Style.NumberFormat.Format = "#,##0.00";
                     ws.Cell(row, 3).Value = b.SpentAmount;
@@ -255,7 +272,7 @@ public static class ExportService
 
                 foreach (var c in breakdown)
                 {
-                    ws.Cell(row, 1).Value = $"{c.Icon} {c.Name}";
+                    ws.Cell(row, 1).Value = EscapeForExcel($"{c.Icon} {c.Name}");
                     ws.Cell(row, 2).Value = c.Amount;
                     ws.Cell(row, 2).Style.NumberFormat.Format = "#,##0.00";
                     row++;

--- a/DailyPlanner/Services/FinanceCalculations.cs
+++ b/DailyPlanner/Services/FinanceCalculations.cs
@@ -5,6 +5,12 @@ namespace DailyPlanner.Services;
 /// <summary>Pure math helpers for finance calculations. No side effects.</summary>
 public static class FinanceCalculations
 {
+    /// <summary>Average weeks per calendar month (52 weeks / 12 months ≈ 4.333), rounded to 2dp.</summary>
+    public const decimal WeeksPerMonth = 4.33m;
+
+    /// <summary>Average bi-weekly periods per calendar month (26 / 12 ≈ 2.167), rounded to 2dp.</summary>
+    public const decimal BiweeksPerMonth = 2.17m;
+
     public static decimal TotalPaid(IEnumerable<decimal> payments) => payments.Sum();
 
     public static decimal RemainingDebt(decimal amount, IEnumerable<decimal> payments)
@@ -19,15 +25,22 @@ public static class FinanceCalculations
     public static double SavingsRatePercent(decimal savings, decimal income)
         => income > 0 ? Math.Max(0, Math.Round((double)(savings / income) * 100, 1)) : 0;
 
-    /// <summary>Normalize recurring payment amount to its monthly equivalent.</summary>
+    /// <summary>
+    /// Normalize a recurring payment amount to its monthly equivalent.
+    /// Throws on unknown frequencies — adding a new <see cref="PaymentFrequency"/>
+    /// value should fail loudly here so callers can be updated, instead of silently
+    /// counting that payment as zero (the previous behaviour).
+    /// </summary>
     public static decimal MonthlyEquivalent(PaymentFrequency frequency, decimal amount) => frequency switch
     {
         PaymentFrequency.Monthly => amount,
-        PaymentFrequency.Weekly => amount * 4.33m,
-        PaymentFrequency.Biweekly => amount * 2.17m,
+        PaymentFrequency.Weekly => amount * WeeksPerMonth,
+        PaymentFrequency.Biweekly => amount * BiweeksPerMonth,
         PaymentFrequency.Quarterly => amount / 3,
         PaymentFrequency.Yearly => amount / 12,
-        _ => 0
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(frequency), frequency,
+            $"Unknown payment frequency '{frequency}'. Add a case in MonthlyEquivalent.")
     };
 
     /// <summary>Sum of monthly-equivalent amounts for all active expense recurring payments.</summary>

--- a/DailyPlanner/Services/SingleInstanceGuard.cs
+++ b/DailyPlanner/Services/SingleInstanceGuard.cs
@@ -5,7 +5,7 @@ using System.Windows;
 
 namespace DailyPlanner.Services;
 
-public static class SingleInstanceGuard
+public static partial class SingleInstanceGuard
 {
     private const string MutexName = @"Global\DailyPlanner_Mutex_c3f4a2e1";
     private const string EventName = @"Global\DailyPlanner_Activate_c3f4a2e1";
@@ -96,15 +96,15 @@ public static class SingleInstanceGuard
         }
     }
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool SetForegroundWindow(nint hWnd);
+    private static partial bool SetForegroundWindow(nint hWnd);
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool ShowWindow(nint hWnd, int nCmdShow);
+    private static partial bool ShowWindow(nint hWnd, int nCmdShow);
 
-    [DllImport("user32.dll")]
+    [LibraryImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool IsIconic(nint hWnd);
+    private static partial bool IsIconic(nint hWnd);
 }

--- a/DailyPlanner/Themes/RefreshTokens.xaml
+++ b/DailyPlanner/Themes/RefreshTokens.xaml
@@ -31,10 +31,11 @@
          Use UPPERCASE in XAML text — no automatic transform applied. -->
     <Style x:Key="MicroLabel" TargetType="TextBlock">
         <Setter Property="FontFamily" Value="{StaticResource FontMono}"/>
-        <Setter Property="FontSize" Value="10"/>
+        <Setter Property="FontSize" Value="11"/>
         <Setter Property="FontWeight" Value="Black"/>
         <Setter Property="Foreground" Value="{DynamicResource MutedBrush}"/>
         <Setter Property="Typography.NumeralStyle" Value="Lining"/>
+        <Setter Property="Typography.Capitals" Value="AllSmallCaps"/>
         <Setter Property="TextOptions.TextFormattingMode" Value="Ideal"/>
     </Style>
 


### PR DESCRIPTION
Closes 4 of the remaining audit items in one shot. Each is independent and small.

## Excel formula-injection
 + 'EscapeForExcel' +  helper added. Prefixes  + "'" +  to any user-controlled string starting with =, +, -, @, tab, or CR — Excel will display the apostrophe invisibly but won't evaluate the cell. Wrapped 11 user-controlled callsites (task/goal/note/habit text + finance descriptions + category concatenations).

## P/Invoke -> LibraryImport
 + 'SingleInstanceGuard' +  moved from  + '[DllImport]' +  to  + '[LibraryImport]' + . Class is now  + 'static partial' + . Adds  + 'AllowUnsafeBlocks=true' +  (required for the source generator's marshalling stubs).

## FinanceCalculations constants
 + 'WeeksPerMonth = 4.33m' +  and  + 'BiweeksPerMonth = 2.17m' +  extracted from the switch with explanatory comments (52/12 and 26/12). The  + '_ => 0' +  silent default now throws  + 'ArgumentOutOfRangeException' +  — adding a new  + 'PaymentFrequency' +  enum value will fail fast at the call-site instead of silently dropping payments.

## MicroLabel typography
RefreshTokens.xaml —  + 'MicroLabel' +  now uses  + 'Typography.Capitals=AllSmallCaps' + . Inter and JetBrains Mono both ship the  + 'smcp' +  feature so Title Case Loc strings render as proper small-caps without binding changes. Bumped 10 -> 11px for legibility.  + 'MicroLabelDim' +  /  + 'MicroLabelAccent' +  inherit via BasedOn.

## Out of scope (deferred)
* FluentAssertions -> Shouldly: 119 callsites, dedicated PR
* God-objects refactor: needs design discussion, will follow the architecture audit