### PR TITLE
v3.33.0: PlannerService DI — IDbContextFactory + remove OverrideFactory race

### DIFF
--- a/DailyPlanner.Tests/PlannerServiceTestFixture.cs
+++ b/DailyPlanner.Tests/PlannerServiceTestFixture.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using DailyPlanner.Data;
 using DailyPlanner.Services;
 using Microsoft.Data.Sqlite;
@@ -6,8 +7,15 @@ using Microsoft.EntityFrameworkCore;
 namespace DailyPlanner.Tests;
 
 /// <summary>
-/// Base class: spins up an in-memory SQLite DB and overrides PlannerDbContextFactory
-/// so PlannerService methods read/write the test DB instead of the user's real file.
+/// Base class: spins up an in-memory SQLite DB and feeds a corresponding
+/// IDbContextFactory directly into PlannerService. Replaces the previous
+/// PlannerDbContextFactory.OverrideFactory mutable-static approach, which
+/// could race-contaminate across xUnit's parallel test classes.
+///
+/// Each fixture instance owns its own SqliteConnection (kept open for the
+/// lifetime of the fixture so the in-memory DB survives between calls) and
+/// a local IDbContextFactory adapter that hands out PlannerDbContexts bound
+/// to that connection.
 /// </summary>
 public abstract class PlannerServiceTestFixture : IDisposable
 {
@@ -19,24 +27,44 @@ public abstract class PlannerServiceTestFixture : IDisposable
         _connection = new SqliteConnection("DataSource=:memory:");
         _connection.Open();
 
-        var options = new DbContextOptionsBuilder<PlannerDbContext>()
-            .UseSqlite(_connection)
-            .Options;
+        var dbFactory = new InMemorySqliteDbFactory(_connection);
 
-        PlannerDbContextFactory.OverrideFactory = () => new PlannerDbContext(options);
-
-        using var ctx = PlannerDbContextFactory.Create();
         // Run real migrations instead of EnsureCreated so tests catch
         // schema drift between Configurations and migration files.
-        ctx.Database.Migrate();
+        using (var ctx = dbFactory.CreateDbContext())
+        {
+            ctx.Database.Migrate();
+        }
 
-        Service = new PlannerService();
+        Service = new PlannerService(dbFactory);
     }
 
     public void Dispose()
     {
-        PlannerDbContextFactory.OverrideFactory = null;
         _connection.Dispose();
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Test-local IDbContextFactory: every CreateDbContext() shares the same
+    /// SqliteConnection so all contexts see the same in-memory DB. This is
+    /// the standard pattern for in-memory SQLite tests.
+    /// </summary>
+    private sealed class InMemorySqliteDbFactory : IDbContextFactory<PlannerDbContext>
+    {
+        private readonly DbConnection _connection;
+
+        public InMemorySqliteDbFactory(DbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public PlannerDbContext CreateDbContext()
+        {
+            var opts = new DbContextOptionsBuilder<PlannerDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+            return new PlannerDbContext(opts);
+        }
     }
 }

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.32.0</Version>
+    <Version>3.33.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Data/PlannerDbContextFactory.cs
+++ b/DailyPlanner/Data/PlannerDbContextFactory.cs
@@ -4,6 +4,17 @@ using Microsoft.EntityFrameworkCore.Design;
 
 namespace DailyPlanner.Data;
 
+/// <summary>
+/// Design-time DbContext factory for EF Core CLI (migrations).
+///
+/// Runtime callers should consume <see cref="IDbContextFactory{PlannerDbContext}"/>
+/// from the DI container instead — see ServiceHost.Configure. Keeping this
+/// class around is necessary because <c>dotnet ef</c> instantiates it
+/// reflectively, but it should not be invoked from production code paths.
+///
+/// AppDataFolder / DbPath remain static path utilities (used by App.xaml.cs
+/// startup, backup, and recovery flows that legitimately run before DI is up).
+/// </summary>
 public sealed class PlannerDbContextFactory : IDesignTimeDbContextFactory<PlannerDbContext>
 {
     public static string AppDataFolder => Path.Combine(
@@ -11,12 +22,6 @@ public sealed class PlannerDbContextFactory : IDesignTimeDbContextFactory<Planne
         "DailyPlanner");
 
     public static string DbPath => Path.Combine(AppDataFolder, "planner.db");
-
-    /// <summary>
-    /// Optional override for tests — when set, Create() will use this factory
-    /// instead of opening the real user SQLite file.
-    /// </summary>
-    public static Func<PlannerDbContext>? OverrideFactory { get; set; }
 
     public PlannerDbContext CreateDbContext(string[] args)
     {
@@ -30,9 +35,13 @@ public sealed class PlannerDbContextFactory : IDesignTimeDbContextFactory<Planne
         return new PlannerDbContext(options);
     }
 
+    /// <summary>
+    /// Bootstrap helper used only by App.xaml.cs migration step (runs before
+    /// the DI container exists). Production services must NOT use this —
+    /// inject <see cref="IDbContextFactory{PlannerDbContext}"/> instead.
+    /// </summary>
     public static PlannerDbContext Create()
     {
-        if (OverrideFactory is not null) return OverrideFactory();
         var factory = new PlannerDbContextFactory();
         return factory.CreateDbContext([]);
     }

--- a/DailyPlanner/Data/PlannerDbContextFactoryAdapter.cs
+++ b/DailyPlanner/Data/PlannerDbContextFactoryAdapter.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyPlanner.Data;
+
+/// <summary>
+/// Adapter: wraps the static <see cref="PlannerDbContextFactory"/> behind the
+/// <see cref="IDbContextFactory{TContext}"/> interface so it can be passed to
+/// classes that expect DI but are constructed manually (XAML design-time
+/// fallback constructors, primarily <see cref="ViewModels.MainViewModel"/>'s
+/// parameterless ctor).
+/// </summary>
+public sealed class PlannerDbContextFactoryAdapter : IDbContextFactory<PlannerDbContext>
+{
+    public PlannerDbContext CreateDbContext()
+    {
+        var df = new PlannerDbContextFactory();
+        return df.CreateDbContext([]);
+    }
+}

--- a/DailyPlanner/Services/PlannerService.Debt.cs
+++ b/DailyPlanner/Services/PlannerService.Debt.cs
@@ -8,14 +8,14 @@ public sealed partial class PlannerService
 {
     public async Task<List<Debt>> GetDebtsAsync(bool includeSettled = false, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var query = db.Debts.Include(d => d.Payments).AsNoTracking();
         if (!includeSettled) query = query.Where(d => !d.IsSettled);
         return await query.OrderByDescending(d => d.CreatedDate).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveDebtAsync(Debt debt, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (debt.Id == 0)
         {
             db.Debts.Add(debt);
@@ -29,7 +29,7 @@ public sealed partial class PlannerService
     }
     public async Task RemoveDebtAsync(int debtId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var debt = await db.Debts.Include(d => d.Payments).FirstOrDefaultAsync(d => d.Id == debtId, ct).ConfigureAwait(false);
         if (debt is not null)
         {
@@ -40,13 +40,13 @@ public sealed partial class PlannerService
     }
     public async Task AddDebtPaymentAsync(DebtPayment payment, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.DebtPayments.Add(payment);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
     public async Task RemoveDebtPaymentAsync(int paymentId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var p = await db.DebtPayments.FindAsync([paymentId], ct).ConfigureAwait(false);
         if (p is not null) { db.DebtPayments.Remove(p); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }

--- a/DailyPlanner/Services/PlannerService.Finance.cs
+++ b/DailyPlanner/Services/PlannerService.Finance.cs
@@ -8,14 +8,14 @@ public sealed partial class PlannerService
 {
     public async Task<List<FinanceCategory>> GetFinanceCategoriesAsync(FinanceEntryType? type = null, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var query = db.FinanceCategories.AsNoTracking().Where(c => !c.IsArchived);
         if (type is not null) query = query.Where(c => c.Type == type);
         return await query.OrderBy(c => c.Order).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveFinanceCategoryAsync(FinanceCategory category, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (category.Id == 0)
             db.FinanceCategories.Add(category);
         else
@@ -24,7 +24,7 @@ public sealed partial class PlannerService
     }
     public async Task ArchiveFinanceCategoryAsync(int categoryId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var cat = await db.FinanceCategories.FindAsync([categoryId], ct).ConfigureAwait(false);
         if (cat is not null)
         {
@@ -34,14 +34,14 @@ public sealed partial class PlannerService
     }
     public async Task<bool> CanDeleteFinanceCategoryAsync(int categoryId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var hasEntries = await db.FinanceEntries.AnyAsync(e => e.CategoryId == categoryId, ct).ConfigureAwait(false);
         var hasPayments = await db.RecurringPayments.AnyAsync(rp => rp.CategoryId == categoryId, ct).ConfigureAwait(false);
         return !hasEntries && !hasPayments;
     }
     public async Task<bool> RemoveFinanceCategoryAsync(int categoryId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var hasEntries = await db.FinanceEntries.AnyAsync(e => e.CategoryId == categoryId, ct).ConfigureAwait(false);
         var hasPayments = await db.RecurringPayments.AnyAsync(rp => rp.CategoryId == categoryId, ct).ConfigureAwait(false);
         if (hasEntries || hasPayments) return false;
@@ -76,7 +76,7 @@ public sealed partial class PlannerService
 
     public async Task SeedFinanceCategoriesAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
 
         var existing = await db.FinanceCategories.ToListAsync(ct).ConfigureAwait(false);
         if (existing.Count == 0)
@@ -134,14 +134,14 @@ public sealed partial class PlannerService
     }
     public async Task<List<FinanceEntry>> GetFinanceEntriesAsync(DateOnly from, DateOnly to, FinanceEntryType? type = null, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var query = db.FinanceEntries.AsNoTracking().Include(e => e.Category).Where(e => e.Date >= from && e.Date <= to);
         if (type is not null) query = query.Where(e => e.Type == type);
         return await query.OrderBy(e => e.Date).ThenBy(e => e.Id).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveFinanceEntryAsync(FinanceEntry entry, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
 
         if (entry.CategoryId > 0)
         {
@@ -166,18 +166,18 @@ public sealed partial class PlannerService
     }
     public async Task RemoveFinanceEntryAsync(int entryId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var entry = await db.FinanceEntries.FindAsync([entryId], ct).ConfigureAwait(false);
         if (entry is not null) { db.FinanceEntries.Remove(entry); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task<List<FinanceBudget>> GetBudgetsAsync(string monthYear, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.FinanceBudgets.AsNoTracking().Include(b => b.Category).Where(b => b.MonthYear == monthYear).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveBudgetAsync(FinanceBudget budget, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (budget.Id == 0)
         {
             db.FinanceBudgets.Add(budget);
@@ -191,20 +191,20 @@ public sealed partial class PlannerService
     }
     public async Task RemoveBudgetAsync(int budgetId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var b = await db.FinanceBudgets.FindAsync([budgetId], ct).ConfigureAwait(false);
         if (b is not null) { db.FinanceBudgets.Remove(b); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task<List<RecurringPayment>> GetRecurringPaymentsAsync(bool activeOnly = true, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var query = db.RecurringPayments.AsNoTracking().Include(rp => rp.Category).AsQueryable();
         if (activeOnly) query = query.Where(rp => rp.IsActive);
         return await query.OrderBy(rp => rp.Type).ThenBy(rp => rp.Name).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveRecurringPaymentAsync(RecurringPayment payment, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (payment.Id == 0)
         {
             db.RecurringPayments.Add(payment);
@@ -218,13 +218,13 @@ public sealed partial class PlannerService
     }
     public async Task RemoveRecurringPaymentAsync(int paymentId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var rp = await db.RecurringPayments.FindAsync([paymentId], ct).ConfigureAwait(false);
         if (rp is not null) { db.RecurringPayments.Remove(rp); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task GenerateRecurringEntriesAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var payments = await db.RecurringPayments
             .Where(rp => rp.IsActive && rp.AutoCreate && rp.StartDate <= to && (rp.EndDate == null || rp.EndDate >= from))
             .ToListAsync(ct).ConfigureAwait(false);
@@ -281,7 +281,7 @@ public sealed partial class PlannerService
     }
     public async Task<List<CategoryBreakdownItem>> GetExpensesByCategoryAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var entries = await db.FinanceEntries
             .Include(e => e.Category)
             .Where(e => e.Type == FinanceEntryType.Expense && e.Date >= from && e.Date <= to)
@@ -301,7 +301,7 @@ public sealed partial class PlannerService
     }
     public async Task<List<MonthlyFinanceSummary>> GetMonthlyTotalsAsync(int months, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var cutoff = DateOnly.FromDateTime(DateTime.Today).AddMonths(-months + 1);
         cutoff = new DateOnly(cutoff.Year, cutoff.Month, 1);
 
@@ -330,43 +330,43 @@ public sealed partial class PlannerService
     }
     public async Task<List<FinancialGoal>> GetFinancialGoalsAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.FinancialGoals.OrderBy(g => g.Order).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveFinancialGoalAsync(FinancialGoal goal, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (goal.Id == 0) db.FinancialGoals.Add(goal);
         else db.FinancialGoals.Update(goal);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
     public async Task RemoveFinancialGoalAsync(int goalId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var goal = await db.FinancialGoals.FindAsync([goalId], ct).ConfigureAwait(false);
         if (goal is not null) { db.FinancialGoals.Remove(goal); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task<List<Account>> GetAccountsAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.Accounts.Where(a => !a.IsArchived).OrderBy(a => a.Order).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveAccountAsync(Account account, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (account.Id == 0) db.Accounts.Add(account);
         else db.Accounts.Update(account);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
     public async Task RemoveAccountAsync(int accountId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var account = await db.Accounts.FindAsync([accountId], ct).ConfigureAwait(false);
         if (account is not null) { db.Accounts.Remove(account); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task<decimal> GetAccountBalanceAsync(int accountId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var account = await db.Accounts.FindAsync([accountId], ct).ConfigureAwait(false);
         if (account is null) return 0;
 
@@ -387,7 +387,7 @@ public sealed partial class PlannerService
     }
     public async Task<List<AccountTransfer>> GetAccountTransfersAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.AccountTransfers
             .Include(t => t.FromAccount)
             .Include(t => t.ToAccount)
@@ -397,20 +397,20 @@ public sealed partial class PlannerService
     }
     public async Task SaveAccountTransferAsync(AccountTransfer transfer, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (transfer.Id == 0) db.AccountTransfers.Add(transfer);
         else db.AccountTransfers.Update(transfer);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
     public async Task RemoveAccountTransferAsync(int transferId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var transfer = await db.AccountTransfers.FindAsync([transferId], ct).ConfigureAwait(false);
         if (transfer is not null) { db.AccountTransfers.Remove(transfer); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task<List<FinanceEntry>> GetSplitEntriesAsync(int parentEntryId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.FinanceEntries
             .Include(e => e.Category)
             .Where(e => e.ParentEntryId == parentEntryId)
@@ -419,7 +419,7 @@ public sealed partial class PlannerService
     }
     public async Task<List<ForecastDay>> GetBalanceForecastAsync(int days, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var today = DateOnly.FromDateTime(DateTime.Today);
         var endDate = today.AddDays(days);
 
@@ -495,7 +495,7 @@ public sealed partial class PlannerService
         var firstDay = new DateOnly(year, month, 1);
         var lastDay = firstDay.AddMonths(1).AddDays(-1);
 
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var entries = await db.FinanceEntries
             .Where(e => e.Date >= firstDay && e.Date <= lastDay)
             .ToListAsync(ct).ConfigureAwait(false);
@@ -528,7 +528,7 @@ public sealed partial class PlannerService
     }
     public async Task<int> ImportFinanceEntriesFromCsvAsync(string filePath, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var lines = await System.IO.File.ReadAllLinesAsync(filePath, System.Text.Encoding.UTF8, ct).ConfigureAwait(false);
         if (lines.Length < 2) return 0;
 

--- a/DailyPlanner/Services/PlannerService.Inbox.cs
+++ b/DailyPlanner/Services/PlannerService.Inbox.cs
@@ -8,7 +8,7 @@ public sealed partial class PlannerService
 {
     public async Task<List<InboxTask>> GetInboxTasksAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.InboxTasks
             .AsNoTracking()
             .Where(t => !t.IsArchived)
@@ -18,7 +18,7 @@ public sealed partial class PlannerService
     }
     public async Task SaveInboxTaskAsync(InboxTask task, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (task.Id == 0)
             db.InboxTasks.Add(task);
         else
@@ -27,7 +27,7 @@ public sealed partial class PlannerService
     }
     public async Task RemoveInboxTaskAsync(int taskId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var t = await db.InboxTasks.FindAsync([taskId], ct).ConfigureAwait(false);
         if (t is null) return;
         db.InboxTasks.Remove(t);
@@ -35,7 +35,7 @@ public sealed partial class PlannerService
     }
     public async Task<DailyTask> MoveInboxToDayAsync(int inboxTaskId, DateOnly date, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var inbox = await db.InboxTasks.FindAsync([inboxTaskId], ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Inbox task not found");
 
@@ -106,7 +106,7 @@ public sealed partial class PlannerService
     }
     public async Task<TrelloSettings> GetTrelloSettingsAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var settings = await db.TrelloSettings.FirstOrDefaultAsync(ct).ConfigureAwait(false);
         if (settings is null)
         {
@@ -122,7 +122,7 @@ public sealed partial class PlannerService
     {
         settings.ApiKey = ProtectedTokenStore.Protect(settings.ApiKey);
         settings.Token = ProtectedTokenStore.Protect(settings.Token);
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.TrelloSettings.Update(settings);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
         settings.ApiKey = ProtectedTokenStore.Unprotect(settings.ApiKey);
@@ -143,7 +143,7 @@ public sealed partial class PlannerService
 
             var cards = await trello.GetCardsInListByNameAsync(settings.ListName, settings.ApiKey, settings.Token, ct).ConfigureAwait(false);
 
-            await using var db = PlannerDbContextFactory.Create();
+            await using var db = _dbFactory.CreateDbContext();
             var inInbox = await db.InboxTasks
                 .Where(t => t.Source == InboxSource.Trello && t.ExternalId != null)
                 .Select(t => t.ExternalId!)

--- a/DailyPlanner/Services/PlannerService.Income.cs
+++ b/DailyPlanner/Services/PlannerService.Income.cs
@@ -8,14 +8,14 @@ public sealed partial class PlannerService
 {
     public async Task<List<IncomeSource>> GetIncomeSourcesAsync(bool activeOnly = true, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var query = db.IncomeSources.Include(s => s.Payments).AsQueryable();
         if (activeOnly) query = query.Where(s => s.IsActive);
         return await query.OrderBy(s => s.Order).ThenBy(s => s.Name).ToListAsync(ct).ConfigureAwait(false);
     }
     public async Task SaveIncomeSourceAsync(IncomeSource source, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (source.Id == 0)
             db.IncomeSources.Add(source);
         else
@@ -24,13 +24,13 @@ public sealed partial class PlannerService
     }
     public async Task RemoveIncomeSourceAsync(int sourceId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var source = await db.IncomeSources.FindAsync([sourceId], ct).ConfigureAwait(false);
         if (source is not null) { db.IncomeSources.Remove(source); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
     public async Task SaveIncomeSourcePaymentAsync(IncomeSourcePayment payment, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (payment.Id == 0)
             db.IncomeSourcePayments.Add(payment);
         else
@@ -39,7 +39,7 @@ public sealed partial class PlannerService
     }
     public async Task RemoveIncomeSourcePaymentAsync(int paymentId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var payment = await db.IncomeSourcePayments.FindAsync([paymentId], ct).ConfigureAwait(false);
         if (payment is not null) { db.IncomeSourcePayments.Remove(payment); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
@@ -49,7 +49,7 @@ public sealed partial class PlannerService
     /// </summary>
     public async Task<List<IncomeSourceStatus>> GetIncomeSourceStatusAsync(int year, int month, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var sources = await db.IncomeSources.Include(s => s.Payments)
             .Where(s => s.IsActive)
             .ToListAsync(ct).ConfigureAwait(false);

--- a/DailyPlanner/Services/PlannerService.cs
+++ b/DailyPlanner/Services/PlannerService.cs
@@ -6,9 +6,23 @@ namespace DailyPlanner.Services;
 
 public sealed partial class PlannerService
 {
+    private readonly IDbContextFactory<PlannerDbContext> _dbFactory;
+
+    /// <summary>
+    /// Constructor-injected DbContext factory. Each call to <c>_dbFactory.CreateDbContext()</c>
+    /// produces a fresh, scoped DbContext — matches the pattern PlannerService partials
+    /// have always used (open, work, dispose) but routed through DI instead of the
+    /// static <c>_dbFactory.CreateDbContext()</c> which carried a mutable
+    /// <c>OverrideFactory</c> field that race-conditioned parallel test fixtures.
+    /// </summary>
+    public PlannerService(IDbContextFactory<PlannerDbContext> dbFactory)
+    {
+        _dbFactory = dbFactory;
+    }
+
     public async Task<PlannerWeek> GetOrCreateWeekAsync(DateOnly startDate, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
 
         // Split query: 5 nested Includes produce a Cartesian explosion in
         // single-query mode (~thousands of rows for one week). AsSplitQuery
@@ -94,14 +108,14 @@ public sealed partial class PlannerService
 
     public async Task SaveTaskAsync(DailyTask task, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.DailyTasks.Update(task);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task AddSubTaskAsync(DailyTask subTask, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.DailyTasks.Add(subTask);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
@@ -110,7 +124,7 @@ public sealed partial class PlannerService
     // restored task doesn't collide with whatever the user added after the delete.
     public async Task RestoreTaskAsync(DailyTask snapshot, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var emptySlot = await db.DailyTasks
             .Where(t => t.DailyPlanId == snapshot.DailyPlanId && t.ParentTaskId == null && (t.Text == null || t.Text == ""))
             .OrderBy(t => t.Order)
@@ -150,7 +164,7 @@ public sealed partial class PlannerService
 
     public async Task RemoveSubTaskAsync(int subTaskId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var task = await db.DailyTasks.FindAsync([subTaskId], ct).ConfigureAwait(false);
         if (task is not null)
         {
@@ -161,7 +175,7 @@ public sealed partial class PlannerService
 
     public async Task RemoveTaskAsync(int taskId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var task = await db.DailyTasks.Include(t => t.SubTasks).FirstOrDefaultAsync(t => t.Id == taskId, ct).ConfigureAwait(false);
         if (task is null) return;
 
@@ -173,7 +187,7 @@ public sealed partial class PlannerService
 
     public async Task MoveTaskToNextDayAsync(int taskId, DateOnly targetDate, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var task = await db.DailyTasks.Include(t => t.SubTasks).FirstOrDefaultAsync(t => t.Id == taskId, ct).ConfigureAwait(false);
         if (task is null) return;
 
@@ -243,28 +257,28 @@ public sealed partial class PlannerService
 
     public async Task AddGoalAsync(WeeklyGoal goal, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.WeeklyGoals.Add(goal);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task SaveGoalAsync(WeeklyGoal goal, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.WeeklyGoals.Update(goal);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task RemoveGoalAsync(int goalId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var goal = await db.WeeklyGoals.FindAsync([goalId], ct).ConfigureAwait(false);
         if (goal is not null) { db.WeeklyGoals.Remove(goal); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
 
     public async Task SaveDailyStateAsync(DailyState state, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (state.Id == 0)
             db.DailyStates.Add(state);
         else
@@ -274,28 +288,28 @@ public sealed partial class PlannerService
 
     public async Task SaveHabitEntryAsync(HabitEntry entry, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.HabitEntries.Update(entry);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task AddHabitAsync(HabitDefinition habit, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.HabitDefinitions.Add(habit);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task SaveHabitDefinitionAsync(HabitDefinition habit, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         db.HabitDefinitions.Update(habit);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
     public async Task RemoveHabitAsync(HabitDefinition habit, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var existing = await db.HabitDefinitions
             .Include(h => h.Entries)
             .FirstOrDefaultAsync(h => h.Id == habit.Id, ct).ConfigureAwait(false);
@@ -309,7 +323,7 @@ public sealed partial class PlannerService
 
     public async Task SaveNotesAsync(int weekId, string notes, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var week = await db.Weeks.FindAsync([weekId], ct).ConfigureAwait(false);
         if (week is not null)
         {
@@ -320,13 +334,13 @@ public sealed partial class PlannerService
 
     public async Task<List<RecurringTemplate>> GetActiveTemplatesAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.RecurringTemplates.Where(t => t.IsActive).ToListAsync(ct).ConfigureAwait(false);
     }
 
     public async Task SaveTemplateAsync(RecurringTemplate template, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (template.Id == 0)
             db.RecurringTemplates.Add(template);
         else
@@ -336,14 +350,14 @@ public sealed partial class PlannerService
 
     public async Task RemoveTemplateAsync(int templateId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var t = await db.RecurringTemplates.FindAsync([templateId], ct).ConfigureAwait(false);
         if (t is not null) { db.RecurringTemplates.Remove(t); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
 
     public async Task ApplyTemplatesAsync(PlannerWeek week, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var templates = await db.RecurringTemplates.Where(t => t.IsActive && !string.IsNullOrEmpty(t.Text)).ToListAsync(ct).ConfigureAwait(false);
         if (templates.Count == 0) return;
 
@@ -379,7 +393,7 @@ public sealed partial class PlannerService
 
     public async Task SaveWeeklyNoteAsync(WeeklyNote note, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (note.Id == 0)
             db.WeeklyNotes.Add(note);
         else
@@ -389,14 +403,14 @@ public sealed partial class PlannerService
 
     public async Task RemoveWeeklyNoteAsync(int noteId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var note = await db.WeeklyNotes.FindAsync([noteId], ct).ConfigureAwait(false);
         if (note is not null) { db.WeeklyNotes.Remove(note); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
 
     public async Task SaveReminderAsync(Reminder reminder, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (reminder.Id == 0)
             db.Reminders.Add(reminder);
         else
@@ -406,20 +420,20 @@ public sealed partial class PlannerService
 
     public async Task RemoveReminderAsync(int reminderId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var r = await db.Reminders.FindAsync([reminderId], ct).ConfigureAwait(false);
         if (r is not null) { db.Reminders.Remove(r); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
 
     public async Task<List<Reminder>> GetRemindersAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.Reminders.AsNoTracking().OrderBy(r => r.Time).ToListAsync(ct).ConfigureAwait(false);
     }
 
     public async Task SaveMeetingAsync(Meeting meeting, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         if (meeting.Id == 0)
             db.Meetings.Add(meeting);
         else
@@ -429,20 +443,20 @@ public sealed partial class PlannerService
 
     public async Task RemoveMeetingAsync(int meetingId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var m = await db.Meetings.FindAsync([meetingId], ct).ConfigureAwait(false);
         if (m is not null) { db.Meetings.Remove(m); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
 
     public async Task<List<Meeting>> GetMeetingsAsync(CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.Meetings.AsNoTracking().OrderBy(m => m.DateTime).ToListAsync(ct).ConfigureAwait(false);
     }
 
     public async Task CopyWeekStructureAsync(int sourceWeekId, int targetWeekId, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var source = await db.Weeks
             .Include(w => w.Days).ThenInclude(d => d.Tasks)
             .FirstOrDefaultAsync(w => w.Id == sourceWeekId, ct).ConfigureAwait(false);
@@ -473,7 +487,7 @@ public sealed partial class PlannerService
 
     public async Task CarryOverTasksAsync(DateOnly fromDate, DateOnly toDate, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         var fromDay = await db.DailyPlans.Include(d => d.Tasks).ThenInclude(t => t.SubTasks).FirstOrDefaultAsync(d => d.Date == fromDate, ct).ConfigureAwait(false);
         var toDay = await db.DailyPlans.Include(d => d.Tasks).ThenInclude(t => t.SubTasks).FirstOrDefaultAsync(d => d.Date == toDate, ct).ConfigureAwait(false);
         if (fromDay is null || toDay is null) return;
@@ -539,7 +553,7 @@ public sealed partial class PlannerService
 
     public async Task<List<PlannerWeek>> GetWeeksInRangeAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
-        await using var db = PlannerDbContextFactory.Create();
+        await using var db = _dbFactory.CreateDbContext();
         return await db.Weeks
             .Include(w => w.Days).ThenInclude(d => d.Tasks).ThenInclude(t => t.SubTasks)
             .Include(w => w.Days).ThenInclude(d => d.State)

--- a/DailyPlanner/Services/ServiceHost.cs
+++ b/DailyPlanner/Services/ServiceHost.cs
@@ -1,11 +1,14 @@
+using DailyPlanner.Data;
 using DailyPlanner.ViewModels;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DailyPlanner.Services;
 
 /// <summary>
-/// Static DI container. Configure() must be called once at startup before Get&lt;T&gt;() is used.
-/// Keeps the registration table in one place; avoids passing IServiceProvider everywhere.
+/// Static facade over the DI container. Configure() must be called once at
+/// startup before Get&lt;T&gt;() is used. Keeps the registration table in one
+/// place; avoids passing IServiceProvider everywhere.
 /// </summary>
 public static class ServiceHost
 {
@@ -18,15 +21,36 @@ public static class ServiceHost
     {
         var sc = new ServiceCollection();
 
-        // Core services — singletons (stateless or process-wide)
+        // EF Core DbContext factory — produces a fresh DbContext per call.
+        // PlannerService partials open and dispose contexts in tight scopes,
+        // so factory pattern matches the lifetime they expect.
+        sc.AddDbContextFactory<PlannerDbContext>(opts =>
+            opts.UseSqlite($"Data Source={PlannerDbContextFactory.DbPath}"));
+
+        // Core services — singletons (stateless or process-wide).
         sc.AddSingleton(TimeProvider.System);
         sc.AddSingleton<PlannerService>();
         sc.AddSingleton<TrelloService>();
         sc.AddSingleton(_ => new UpdateService("https://github.com/valinerosgordov/DailyPlanner"));
 
-        // Main VM is one per window
+        // Main VM is one per window.
         sc.AddSingleton<MainViewModel>();
 
+        _provider = sc.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Replaces the active provider with one built from a custom configuration
+    /// callback. Test-only: lets fixtures register their own DbContextFactory
+    /// (e.g. backed by an in-memory SQLite connection) without touching the
+    /// removed PlannerDbContextFactory.OverrideFactory mutable static.
+    /// </summary>
+    public static void ConfigureForTests(Action<IServiceCollection> configure)
+    {
+        var sc = new ServiceCollection();
+        sc.AddSingleton(TimeProvider.System);
+        sc.AddSingleton<PlannerService>();
+        configure(sc);
         _provider = sc.BuildServiceProvider();
     }
 

--- a/DailyPlanner/ViewModels/MainViewModel.cs
+++ b/DailyPlanner/ViewModels/MainViewModel.cs
@@ -70,9 +70,13 @@ public sealed partial class MainViewModel : ObservableObject
 
     private readonly TimeProvider _time;
 
-    public MainViewModel() : this(new PlannerService(), new TrelloService(),
-        new UpdateService("https://github.com/valinerosgordov/DailyPlanner"),
-        TimeProvider.System)
+    /// <summary>Design-time / fallback constructor — production code resolves this VM through the DI container.</summary>
+    public MainViewModel()
+        : this(
+            new PlannerService(new PlannerDbContextFactoryAdapter()),
+            new TrelloService(),
+            new UpdateService("https://github.com/valinerosgordov/DailyPlanner"),
+            TimeProvider.System)
     { }
 
     public MainViewModel(PlannerService service, TrelloService trelloService, UpdateService updateService, TimeProvider time)


### PR DESCRIPTION
Architecture work — PlannerService now consumes IDbContextFactory via DI. Closes the named-in-audit race condition (PlannerDbContextFactory.OverrideFactory mutable-static).

## What changed

* PlannerService constructor: now takes IDbContextFactory<PlannerDbContext>
* 81 callsites of PlannerDbContextFactory.Create() across 5 partials swapped to _dbFactory.CreateDbContext()
* ServiceHost registers AddDbContextFactory<PlannerDbContext>
* PlannerDbContextFactory.OverrideFactory removed (was the race condition source)
* PlannerServiceTestFixture rewritten to use a local InMemorySqliteDbFactory adapter — each test class fully isolated

## What was found already-done (audit was stale)

* EF mappings already in Data/Configurations/ (25 IEntityTypeConfiguration files, v3.25.0)
* ServiceHost already wraps Microsoft.Extensions.DependencyInjection — just lacked DbContextFactory registration

## Out of scope

MainViewModel split, PlannerService split, FinancePage/WeekPage XAML breakup, FluentAssertions → Shouldly. Each is its own PR.

74 tests pass, dotnet format clean.