### PR TITLE
v3.35.0: Subscriptions foundation - extended model + multi-currency + migration

### DIFF
--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.34.0</Version>
+    <Version>3.35.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Data/Configurations/ExchangeRateConfiguration.cs
+++ b/DailyPlanner/Data/Configurations/ExchangeRateConfiguration.cs
@@ -1,0 +1,20 @@
+using DailyPlanner.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DailyPlanner.Data.Configurations;
+
+public sealed class ExchangeRateConfiguration : IEntityTypeConfiguration<ExchangeRate>
+{
+    public void Configure(EntityTypeBuilder<ExchangeRate> e)
+    {
+        e.HasKey(x => x.Id);
+        // One rate per (currency, base, date). Re-running the daily fetch
+        // updates the same row instead of accumulating duplicates.
+        e.HasIndex(x => new { x.CurrencyCode, x.BaseCurrency, x.Date }).IsUnique();
+        e.Property(x => x.CurrencyCode).HasMaxLength(8).IsRequired();
+        e.Property(x => x.BaseCurrency).HasMaxLength(8).IsRequired();
+        e.Property(x => x.Rate).HasColumnType("decimal(18,6)");
+        e.Property(x => x.Source).HasMaxLength(64);
+    }
+}

--- a/DailyPlanner/Data/Configurations/FinanceEntryConfiguration.cs
+++ b/DailyPlanner/Data/Configurations/FinanceEntryConfiguration.cs
@@ -14,8 +14,14 @@ public sealed class FinanceEntryConfiguration : IEntityTypeConfiguration<Finance
         e.HasIndex(fe => fe.RecurringPaymentId);
         e.HasIndex(fe => fe.AccountId);
         e.HasIndex(fe => fe.ParentEntryId);
+        e.HasIndex(fe => fe.IsPaid);
+
         e.Property(fe => fe.Amount).HasColumnType("decimal(18,2)");
         e.Property(fe => fe.Description).HasMaxLength(500);
+        e.Property(fe => fe.Currency).HasMaxLength(8).HasDefaultValue("RUB");
+        e.Property(fe => fe.ExchangeRateToBase).HasColumnType("decimal(18,6)");
+        e.Property(fe => fe.AmountInBaseCurrency).HasColumnType("decimal(18,2)").HasDefaultValue(0m);
+
         e.HasOne(fe => fe.Week).WithMany().HasForeignKey(fe => fe.WeekId).OnDelete(DeleteBehavior.SetNull);
         e.HasOne(fe => fe.RecurringPayment).WithMany(rp => rp.GeneratedEntries).HasForeignKey(fe => fe.RecurringPaymentId).OnDelete(DeleteBehavior.SetNull);
         e.HasOne(fe => fe.Account).WithMany(a => a.Entries).HasForeignKey(fe => fe.AccountId).OnDelete(DeleteBehavior.SetNull);

--- a/DailyPlanner/Data/Configurations/RecurringPaymentConfiguration.cs
+++ b/DailyPlanner/Data/Configurations/RecurringPaymentConfiguration.cs
@@ -11,8 +11,21 @@ public sealed class RecurringPaymentConfiguration : IEntityTypeConfiguration<Rec
         e.HasKey(rp => rp.Id);
         e.HasIndex(rp => rp.CategoryId);
         e.HasIndex(rp => rp.IsActive);
+        e.HasIndex(rp => rp.IsSubscription);
+        e.HasIndex(rp => rp.NextRenewalDate);
+
         e.Property(rp => rp.Name).HasMaxLength(200);
         e.Property(rp => rp.Amount).HasColumnType("decimal(18,2)");
         e.Property(rp => rp.Note).HasMaxLength(1000);
+
+        // Subscription fields — explicit defaults so the migration can apply
+        // them to existing rows without manual SQL.
+        e.Property(rp => rp.IsSubscription).HasDefaultValue(false);
+        e.Property(rp => rp.BillingIntervalMonths).HasDefaultValue(1);
+        e.Property(rp => rp.ListPriceMonthly).HasColumnType("decimal(18,2)");
+        e.Property(rp => rp.AutoRenew).HasDefaultValue(true);
+        e.Property(rp => rp.CancellationNoticeDays).HasDefaultValue(0);
+        e.Property(rp => rp.RenewalRemindDaysBefore).HasMaxLength(64).HasDefaultValue(string.Empty);
+        e.Property(rp => rp.Currency).HasMaxLength(8).HasDefaultValue("RUB");
     }
 }

--- a/DailyPlanner/Data/PlannerDbContext.cs
+++ b/DailyPlanner/Data/PlannerDbContext.cs
@@ -29,6 +29,7 @@ public sealed class PlannerDbContext(DbContextOptions<PlannerDbContext> options)
     public DbSet<IncomeSourcePayment> IncomeSourcePayments => Set<IncomeSourcePayment>();
     public DbSet<InboxTask> InboxTasks => Set<InboxTask>();
     public DbSet<TrelloSettings> TrelloSettings => Set<TrelloSettings>();
+    public DbSet<ExchangeRate> ExchangeRates => Set<ExchangeRate>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/DailyPlanner/Migrations/20260510184824_SubscriptionsFoundation.Designer.cs
+++ b/DailyPlanner/Migrations/20260510184824_SubscriptionsFoundation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DailyPlanner.Migrations
 {
     [DbContext(typeof(PlannerDbContext))]
-    partial class PlannerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510184824_SubscriptionsFoundation")]
+    partial class SubscriptionsFoundation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/DailyPlanner/Migrations/20260510184824_SubscriptionsFoundation.cs
+++ b/DailyPlanner/Migrations/20260510184824_SubscriptionsFoundation.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyPlanner.Migrations
+{
+    /// <inheritdoc />
+    public partial class SubscriptionsFoundation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AutoRenew",
+                table: "RecurringPayments",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BillingIntervalMonths",
+                table: "RecurringPayments",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CancellationNoticeDays",
+                table: "RecurringPayments",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                table: "RecurringPayments",
+                type: "TEXT",
+                maxLength: 8,
+                nullable: false,
+                defaultValue: "RUB");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSubscription",
+                table: "RecurringPayments",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "LastReviewedDate",
+                table: "RecurringPayments",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "ListPriceMonthly",
+                table: "RecurringPayments",
+                type: "decimal(18,2)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "NextRenewalDate",
+                table: "RecurringPayments",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RenewalRemindDaysBefore",
+                table: "RecurringPayments",
+                type: "TEXT",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "TrialEndsOn",
+                table: "RecurringPayments",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "AmountInBaseCurrency",
+                table: "FinanceEntries",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Currency",
+                table: "FinanceEntries",
+                type: "TEXT",
+                maxLength: 8,
+                nullable: false,
+                defaultValue: "RUB");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "ExchangeRateToBase",
+                table: "FinanceEntries",
+                type: "decimal(18,6)",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ExchangeRates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    CurrencyCode = table.Column<string>(type: "TEXT", maxLength: 8, nullable: false),
+                    BaseCurrency = table.Column<string>(type: "TEXT", maxLength: 8, nullable: false),
+                    Rate = table.Column<decimal>(type: "decimal(18,6)", nullable: false),
+                    Date = table.Column<DateOnly>(type: "TEXT", nullable: false),
+                    Source = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExchangeRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringPayments_IsSubscription",
+                table: "RecurringPayments",
+                column: "IsSubscription");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RecurringPayments_NextRenewalDate",
+                table: "RecurringPayments",
+                column: "NextRenewalDate");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinanceEntries_IsPaid",
+                table: "FinanceEntries",
+                column: "IsPaid");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExchangeRates_CurrencyCode_BaseCurrency_Date",
+                table: "ExchangeRates",
+                columns: new[] { "CurrencyCode", "BaseCurrency", "Date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExchangeRates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RecurringPayments_IsSubscription",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RecurringPayments_NextRenewalDate",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FinanceEntries_IsPaid",
+                table: "FinanceEntries");
+
+            migrationBuilder.DropColumn(
+                name: "AutoRenew",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "BillingIntervalMonths",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "CancellationNoticeDays",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "IsSubscription",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "LastReviewedDate",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "ListPriceMonthly",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "NextRenewalDate",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "RenewalRemindDaysBefore",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "TrialEndsOn",
+                table: "RecurringPayments");
+
+            migrationBuilder.DropColumn(
+                name: "AmountInBaseCurrency",
+                table: "FinanceEntries");
+
+            migrationBuilder.DropColumn(
+                name: "Currency",
+                table: "FinanceEntries");
+
+            migrationBuilder.DropColumn(
+                name: "ExchangeRateToBase",
+                table: "FinanceEntries");
+        }
+    }
+}

--- a/DailyPlanner/Models/ExchangeRate.cs
+++ b/DailyPlanner/Models/ExchangeRate.cs
@@ -1,0 +1,30 @@
+namespace DailyPlanner.Models;
+
+/// <summary>
+/// Daily exchange rate snapshot, keyed by (CurrencyCode, BaseCurrency, Date).
+/// Powers historically-stable currency conversions: when a FinanceEntry is
+/// created, the day's rate is captured into <see cref="FinanceEntry.ExchangeRateToBase"/>
+/// so the row's RUB value never drifts as today's rate changes.
+///
+/// Populated by a background ExchangeRateService that pulls from the CBR
+/// API once daily (see ExchangeRateService — separate PR).
+/// </summary>
+public sealed class ExchangeRate
+{
+    public int Id { get; set; }
+
+    /// <summary>ISO 4217 code of the foreign currency (e.g. USD, EUR).</summary>
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    /// <summary>ISO 4217 base currency (RUB by default).</summary>
+    public string BaseCurrency { get; set; } = "RUB";
+
+    /// <summary>Rate: 1 unit of CurrencyCode = Rate units of BaseCurrency.</summary>
+    public decimal Rate { get; set; }
+
+    /// <summary>Date the rate applies to.</summary>
+    public DateOnly Date { get; set; }
+
+    /// <summary>Source identifier for audit (e.g. "cbr.ru", "manual").</summary>
+    public string Source { get; set; } = string.Empty;
+}

--- a/DailyPlanner/Models/FinanceEntry.cs
+++ b/DailyPlanner/Models/FinanceEntry.cs
@@ -15,6 +15,26 @@ public sealed class FinanceEntry
     public int? AccountId { get; set; }
     public int? ParentEntryId { get; set; }
 
+    /// <summary>
+    /// Original currency the transaction happened in (ISO 4217, e.g. USD).
+    /// Pre-currency rows default to RUB through migration backfill.
+    /// </summary>
+    public string Currency { get; set; } = "RUB";
+
+    /// <summary>
+    /// Exchange rate to the base currency (RUB) at the moment the entry was
+    /// created. Stored so that historical totals stay stable even if today's
+    /// rate moves. Null for base-currency entries (rate = 1).
+    /// </summary>
+    public decimal? ExchangeRateToBase { get; set; }
+
+    /// <summary>
+    /// Computed-and-stored Amount * ExchangeRateToBase. Stored (not pure
+    /// computed) because we'd otherwise need a JOIN on every aggregate query.
+    /// Updated whenever Amount, Currency, or ExchangeRateToBase change.
+    /// </summary>
+    public decimal AmountInBaseCurrency { get; set; }
+
     public PlannerWeek? Week { get; set; }
     public FinanceCategory? Category { get; set; }
     public RecurringPayment? RecurringPayment { get; set; }

--- a/DailyPlanner/Models/RecurringPayment.cs
+++ b/DailyPlanner/Models/RecurringPayment.cs
@@ -17,6 +17,79 @@ public sealed class RecurringPayment
     public int RemindDaysBefore { get; set; }
     public string Note { get; set; } = string.Empty;
 
+    // === Subscription-specific fields (added 2026-05) ===
+
+    /// <summary>
+    /// True for SaaS / streaming / hosting / discretionary recurring expenses
+    /// you could cancel. False for utilities, rent, loans — obligatory bills
+    /// that also recur but aren't "subscriptions" in the cancellable sense.
+    /// Separates the two in subscription-burden aggregates.
+    /// </summary>
+    public bool IsSubscription { get; set; }
+
+    /// <summary>
+    /// Months between actual charges. Frequency captures the cadence; this
+    /// captures the commitment window. For monthly billing = 1; for an annual
+    /// hosting plan billed once a year = 12; for a 6-month JetBrains commit
+    /// pack = 6. EffectiveMonthlyCost = Amount / BillingIntervalMonths.
+    /// </summary>
+    public int BillingIntervalMonths { get; set; } = 1;
+
+    /// <summary>
+    /// What the same service would cost if billed monthly (the "no discount"
+    /// tier). Lets us compute annual savings from a longer commitment, and
+    /// surface "you save X by paying yearly" hints.
+    /// </summary>
+    public decimal? ListPriceMonthly { get; set; }
+
+    /// <summary>
+    /// When the entire commitment period renews (or auto-renews). For a yearly
+    /// Timeweb plan paid in March 2026, this is March 2027. Drives the
+    /// renewal-reminder ladder.
+    /// </summary>
+    public DateOnly? NextRenewalDate { get; set; }
+
+    /// <summary>
+    /// True if the provider auto-renews unless cancelled. For these, missing
+    /// the cancellation deadline means an unwanted charge — reminders matter
+    /// more. False for prepaid manual renewals.
+    /// </summary>
+    public bool AutoRenew { get; set; } = true;
+
+    /// <summary>
+    /// Some contracts require cancelling N days before renewal. JetBrains
+    /// pack is "anytime", Timeweb is 0, some hosting/insurance products are
+    /// 30+. CancellationDeadline = NextRenewalDate - CancellationNoticeDays.
+    /// </summary>
+    public int CancellationNoticeDays { get; set; }
+
+    /// <summary>
+    /// Comma-separated days-before-due for staggered reminders. Empty string
+    /// = use legacy RemindDaysBefore (single-shot). Recommended for
+    /// subscriptions: "30,7,1" — gentle nudge, action reminder, last call.
+    /// </summary>
+    public string RenewalRemindDaysBefore { get; set; } = string.Empty;
+
+    /// <summary>
+    /// ISO 4217 code (RUB, USD, EUR, …). Drives currency-aware aggregates so
+    /// foreign-currency subscriptions don't get summed as if they were RUB.
+    /// </summary>
+    public string Currency { get; set; } = "RUB";
+
+    /// <summary>
+    /// Manually-set date when the user last reviewed this subscription
+    /// (kept / cancelled / switched tier). Powers the "audit older than N
+    /// days" prompt so users get nudged to revisit dormant subscriptions.
+    /// </summary>
+    public DateOnly? LastReviewedDate { get; set; }
+
+    /// <summary>
+    /// Optional trial-period end. When set, displayed prominently with a
+    /// dedicated "trial ends in N days" reminder so the user can decide
+    /// whether to keep the subscription before the first real charge.
+    /// </summary>
+    public DateOnly? TrialEndsOn { get; set; }
+
     public FinanceCategory? Category { get; set; }
     public List<FinanceEntry> GeneratedEntries { get; set; } = [];
 }


### PR DESCRIPTION
Foundation for the subscriptions overhaul. No UI yet - that's PR #83. This is data model + migration so subsequent PRs can stand on stable schema.

## RecurringPayment - 10 new fields

* IsSubscription - separates cancellable subs from obligatory bills
* BillingIntervalMonths (default 1) - commitment-window pricing (Timeweb yearly = 12)
* ListPriceMonthly - what it'd cost monthly, drives 'save X by paying yearly'
* NextRenewalDate - drives the renewal reminder ladder
* AutoRenew (default true) - flags providers that auto-charge
* CancellationNoticeDays - for contracts needing N-day pre-notice
* RenewalRemindDaysBefore - CSV ladder, e.g. '30,7,1'
* Currency (default RUB) - ISO 4217, prepares multi-currency
* LastReviewedDate - 'audit older than N days' prompts
* TrialEndsOn - dedicated trial-end reminder

## FinanceEntry - 3 currency fields

* Currency (default RUB)
* ExchangeRateToBase - captured at entry time, frozen for historical stability
* AmountInBaseCurrency - precomputed to avoid JOINs on aggregate queries

## New entity: ExchangeRate

Daily rate snapshots keyed by (CurrencyCode, BaseCurrency, Date). Unique index. Populated by future ExchangeRateService.

## Migration

All NOT NULL columns have inline defaults - non-destructive, runs cleanly on populated DBs. Verified by test fixture running Database.Migrate() against in-memory SQLite.

## Follow-up PRs

* #80 SubscriptionForecastService - pure logic
* #81 Currency conversion via CBR daily fetch
* #82 AutoCreate scheduler - Pending entries materialise on due date
* #83 UI inside FinancePage
* #84 Quick-add (Ctrl+E) + monthly review prompt

74 tests pass, dotnet format clean.