### PR TITLE
v3.36.0: SubscriptionForecastService - pure logic + 20 tests

### DIFF
--- a/DailyPlanner.Tests/SubscriptionForecastServiceTests.cs
+++ b/DailyPlanner.Tests/SubscriptionForecastServiceTests.cs
@@ -1,0 +1,253 @@
+using DailyPlanner.Models;
+using DailyPlanner.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace DailyPlanner.Tests;
+
+public class SubscriptionForecastServiceTests
+{
+    private static readonly DateOnly Today = new(2026, 5, 10);
+
+    private static RecurringPayment NewSub(
+        decimal amount = 590m,
+        int billingMonths = 1,
+        PaymentFrequency frequency = PaymentFrequency.Monthly,
+        int? dayOfMonth = null,
+        DateOnly? start = null,
+        DateOnly? end = null,
+        DateOnly? renewal = null,
+        bool isActive = true,
+        bool isSubscription = true,
+        decimal? listPriceMonthly = null,
+        string currency = "RUB",
+        string remindCsv = "")
+    {
+        return new RecurringPayment
+        {
+            Name = "test",
+            Amount = amount,
+            Type = FinanceEntryType.Expense,
+            Frequency = frequency,
+            DayOfMonth = dayOfMonth,
+            StartDate = start ?? new DateOnly(2026, 1, 1),
+            EndDate = end,
+            IsActive = isActive,
+            IsSubscription = isSubscription,
+            BillingIntervalMonths = billingMonths,
+            ListPriceMonthly = listPriceMonthly,
+            NextRenewalDate = renewal,
+            Currency = currency,
+            RenewalRemindDaysBefore = remindCsv
+        };
+    }
+
+    // ── NextOccurrenceFrom ─────────────────────────────────────────────
+
+    [Fact]
+    public void NextOccurrenceFrom_Inactive_ReturnsNull()
+    {
+        var sub = NewSub(isActive: false);
+        SubscriptionForecastService.NextOccurrenceFrom(sub, Today).Should().BeNull();
+    }
+
+    [Fact]
+    public void NextOccurrenceFrom_EndedBeforeToday_ReturnsNull()
+    {
+        var sub = NewSub(end: new DateOnly(2026, 1, 1));
+        SubscriptionForecastService.NextOccurrenceFrom(sub, Today).Should().BeNull();
+    }
+
+    [Fact]
+    public void NextOccurrenceFrom_RespectsExplicitNextRenewalDate()
+    {
+        var sub = NewSub(renewal: new DateOnly(2027, 3, 15));
+        SubscriptionForecastService.NextOccurrenceFrom(sub, Today)
+            .Should().Be(new DateOnly(2027, 3, 15));
+    }
+
+    [Fact]
+    public void NextOccurrenceFrom_MonthlyWithDayOfMonth_SnapsToCorrectDay()
+    {
+        // Started Jan 15. Today is May 10. Next monthly occurrence after today is May 15.
+        var sub = NewSub(
+            frequency: PaymentFrequency.Monthly,
+            dayOfMonth: 15,
+            start: new DateOnly(2026, 1, 15));
+
+        SubscriptionForecastService.NextOccurrenceFrom(sub, Today)
+            .Should().Be(new DateOnly(2026, 5, 15));
+    }
+
+    [Fact]
+    public void NextOccurrenceFrom_YearlyBillingInterval_AdvancesYearly()
+    {
+        // Timeweb-style: paid March 2026, billingIntervalMonths=12, next March 2027.
+        var sub = NewSub(
+            billingMonths: 12,
+            start: new DateOnly(2026, 3, 15));
+
+        SubscriptionForecastService.NextOccurrenceFrom(sub, Today)
+            .Should().Be(new DateOnly(2027, 3, 15));
+    }
+
+    // ── EnumerateOccurrences ───────────────────────────────────────────
+
+    [Fact]
+    public void EnumerateOccurrences_Monthly30DayWindow_YieldsOne()
+    {
+        var sub = NewSub(
+            frequency: PaymentFrequency.Monthly,
+            dayOfMonth: 20,
+            start: new DateOnly(2026, 4, 20));
+
+        var occs = SubscriptionForecastService.EnumerateOccurrences(sub, Today, window: 30).ToList();
+        occs.Should().HaveCount(1);
+        occs[0].Date.Should().Be(new DateOnly(2026, 5, 20));
+    }
+
+    [Fact]
+    public void EnumerateOccurrences_Weekly60DayWindow_YieldsAboutEight()
+    {
+        var sub = NewSub(
+            frequency: PaymentFrequency.Weekly,
+            start: new DateOnly(2026, 5, 10));
+
+        var occs = SubscriptionForecastService.EnumerateOccurrences(sub, Today, window: 60).ToList();
+        occs.Should().HaveCountGreaterThanOrEqualTo(8);
+        occs.Should().HaveCountLessThanOrEqualTo(9);
+    }
+
+    [Fact]
+    public void EnumerateOccurrences_StopsAtEndDate()
+    {
+        var sub = NewSub(
+            frequency: PaymentFrequency.Monthly,
+            dayOfMonth: 15,
+            start: new DateOnly(2026, 1, 15),
+            end: new DateOnly(2026, 6, 30));
+
+        var occs = SubscriptionForecastService.EnumerateOccurrences(sub, Today, window: 365).ToList();
+        occs.Should().OnlyContain(o => o.Date <= new DateOnly(2026, 6, 30));
+    }
+
+    [Fact]
+    public void EnumerateOccurrences_Inactive_YieldsEmpty()
+    {
+        var sub = NewSub(isActive: false);
+        SubscriptionForecastService.EnumerateOccurrences(sub, Today, 30).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EnumerateOccurrences_ClassifiesStatusCorrectly()
+    {
+        var sub = NewSub(
+            frequency: PaymentFrequency.Monthly,
+            dayOfMonth: 10,
+            start: new DateOnly(2026, 5, 10));
+
+        var occs = SubscriptionForecastService.EnumerateOccurrences(sub, Today, window: 30).ToList();
+        occs[0].Date.Should().Be(Today);
+        occs[0].Status.Should().Be(SubscriptionForecastService.OccurrenceStatus.DueToday);
+    }
+
+    // ── MonthlySubscriptionBurden ──────────────────────────────────────
+
+    [Fact]
+    public void MonthlySubscriptionBurden_SumsEffectiveCost()
+    {
+        // Spotify ₽590 monthly + Timeweb ₽10584 yearly (= ₽882/mo) + Netflix ₽800 monthly
+        var subs = new[]
+        {
+            NewSub(amount: 590m, billingMonths: 1),
+            NewSub(amount: 10584m, billingMonths: 12),
+            NewSub(amount: 800m, billingMonths: 1)
+        };
+
+        SubscriptionForecastService.MonthlySubscriptionBurden(subs)
+            .Should().Be(2272m); // 590 + 882 + 800
+    }
+
+    [Fact]
+    public void MonthlySubscriptionBurden_ExcludesNonSubscriptionsAndInactive()
+    {
+        var subs = new[]
+        {
+            NewSub(amount: 100m, isSubscription: true),
+            NewSub(amount: 200m, isSubscription: false),     // utility, not subscription
+            NewSub(amount: 300m, isSubscription: true, isActive: false)  // paused
+        };
+
+        SubscriptionForecastService.MonthlySubscriptionBurden(subs).Should().Be(100m);
+    }
+
+    // ── AnnualSavingsVsMonthly ─────────────────────────────────────────
+
+    [Fact]
+    public void AnnualSavingsVsMonthly_CalculatesCorrectlyForTimewebCase()
+    {
+        // Pay ₽10584/yr = ₽882/mo. Monthly billing would be ₽980/mo.
+        // Saving = (980 - 882) * 12 = ₽1176/yr
+        var sub = NewSub(amount: 10584m, billingMonths: 12, listPriceMonthly: 980m);
+        SubscriptionForecastService.AnnualSavingsVsMonthly([sub]).Should().Be(1176m);
+    }
+
+    [Fact]
+    public void AnnualSavingsVsMonthly_SkipsWithoutListPriceMonthly()
+    {
+        var sub = NewSub(amount: 590m, listPriceMonthly: null);
+        SubscriptionForecastService.AnnualSavingsVsMonthly([sub]).Should().Be(0m);
+    }
+
+    [Fact]
+    public void AnnualSavingsVsMonthly_SkipsWhenNoDiscount()
+    {
+        // Same price monthly and yearly = no saving
+        var sub = NewSub(amount: 1200m, billingMonths: 12, listPriceMonthly: 100m);
+        SubscriptionForecastService.AnnualSavingsVsMonthly([sub]).Should().Be(0m);
+    }
+
+    // ── ParseRemindLadder ──────────────────────────────────────────────
+
+    [Fact]
+    public void ParseRemindLadder_HandlesWhitespaceAndDuplicates()
+    {
+        var ladder = SubscriptionForecastService.ParseRemindLadder(" 30, 7 , 1 , 7 ");
+        ladder.Should().Equal(1, 7, 30);
+    }
+
+    [Fact]
+    public void ParseRemindLadder_DropsInvalidAndNonPositive()
+    {
+        var ladder = SubscriptionForecastService.ParseRemindLadder("30,abc,0,-5,7");
+        ladder.Should().Equal(7, 30);
+    }
+
+    [Fact]
+    public void ParseRemindLadder_EmptyReturnsEmpty()
+    {
+        SubscriptionForecastService.ParseRemindLadder("").Should().BeEmpty();
+        SubscriptionForecastService.ParseRemindLadder(null!).Should().BeEmpty();
+    }
+
+    // ── StepsCrossingToday ─────────────────────────────────────────────
+
+    [Fact]
+    public void StepsCrossingToday_ReturnsMatchingLadderStep()
+    {
+        // Renewal in 7 days, ladder = [30, 7, 1] → today crosses the "7" step
+        var sub = NewSub(
+            renewal: Today.AddDays(7),
+            remindCsv: "30,7,1");
+
+        var crossing = SubscriptionForecastService.StepsCrossingToday(sub, Today);
+        crossing.Should().Equal(7);
+    }
+
+    [Fact]
+    public void StepsCrossingToday_NoLadder_ReturnsEmpty()
+    {
+        var sub = NewSub(renewal: Today.AddDays(3), remindCsv: "");
+        SubscriptionForecastService.StepsCrossingToday(sub, Today).Should().BeEmpty();
+    }
+}

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.35.0</Version>
+    <Version>3.36.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Services/SubscriptionForecastService.cs
+++ b/DailyPlanner/Services/SubscriptionForecastService.cs
@@ -1,0 +1,199 @@
+using DailyPlanner.Models;
+
+namespace DailyPlanner.Services;
+
+/// <summary>
+/// Pure-logic forecasting of upcoming recurring payments. No DB access, no
+/// HTTP, no DI — call directly from the VM after loading RecurringPayments
+/// from the DbContext. All functions are deterministic given a "now" date,
+/// which makes them trivially testable.
+/// </summary>
+public static class SubscriptionForecastService
+{
+    /// <summary>Status of a forecasted occurrence relative to today.</summary>
+    public enum OccurrenceStatus
+    {
+        /// <summary>Future occurrence within the forecast window.</summary>
+        Pending,
+        /// <summary>Due today.</summary>
+        DueToday,
+        /// <summary>Due within RemindDaysBefore window.</summary>
+        DueSoon,
+        /// <summary>Past due, not paid.</summary>
+        Overdue,
+        /// <summary>Trial expires.</summary>
+        TrialEnding
+    }
+
+    /// <summary>Single forecasted occurrence of a recurring payment.</summary>
+    public sealed record Occurrence(
+        RecurringPayment Payment,
+        DateOnly Date,
+        OccurrenceStatus Status,
+        int DaysFromNow);
+
+    /// <summary>
+    /// Generates all occurrences for the given payment in <paramref name="window"/>
+    /// days from <paramref name="today"/>. Caps at 366 days to avoid runaway loops.
+    /// </summary>
+    public static IEnumerable<Occurrence> EnumerateOccurrences(
+        RecurringPayment payment, DateOnly today, int window)
+    {
+        if (!payment.IsActive) yield break;
+        window = Math.Clamp(window, 1, 366);
+
+        var end = today.AddDays(window);
+        var cursor = NextOccurrenceFrom(payment, today);
+
+        while (cursor.HasValue && cursor.Value <= end)
+        {
+            // Respect EndDate (subscription terminated)
+            if (payment.EndDate.HasValue && cursor.Value > payment.EndDate.Value) yield break;
+
+            var daysFromNow = cursor.Value.DayNumber - today.DayNumber;
+            var status = ClassifyStatus(payment, cursor.Value, today);
+
+            yield return new Occurrence(payment, cursor.Value, status, daysFromNow);
+
+            cursor = StepForward(payment, cursor.Value);
+        }
+    }
+
+    /// <summary>
+    /// First occurrence on or after <paramref name="today"/>. Returns null if the
+    /// payment has ended or has no plausible next date.
+    /// </summary>
+    public static DateOnly? NextOccurrenceFrom(RecurringPayment payment, DateOnly today)
+    {
+        if (!payment.IsActive) return null;
+        if (payment.EndDate.HasValue && payment.EndDate.Value < today) return null;
+
+        // Use NextRenewalDate if set — overrides cadence (Timeweb-yearly case).
+        if (payment.NextRenewalDate.HasValue && payment.NextRenewalDate.Value >= today)
+            return payment.NextRenewalDate;
+
+        // Walk forward from StartDate by Frequency until we reach today.
+        var cursor = payment.StartDate;
+        while (cursor < today)
+        {
+            var next = StepForward(payment, cursor);
+            if (next is null || next.Value <= cursor) return null; // safety stop
+            cursor = next.Value;
+        }
+        return cursor;
+    }
+
+    private static DateOnly? StepForward(RecurringPayment payment, DateOnly from)
+    {
+        // If BillingIntervalMonths is set (>= 1) and the payment is a
+        // commitment-window (Timeweb yearly etc.), step by that. Otherwise
+        // honour Frequency.
+        if (payment.BillingIntervalMonths > 1)
+            return from.AddMonths(payment.BillingIntervalMonths);
+
+        return payment.Frequency switch
+        {
+            PaymentFrequency.Weekly => from.AddDays(7),
+            PaymentFrequency.Biweekly => from.AddDays(14),
+            PaymentFrequency.Monthly => SnapToDayOfMonth(from.AddMonths(1), payment.DayOfMonth),
+            PaymentFrequency.Quarterly => from.AddMonths(3),
+            PaymentFrequency.Yearly => from.AddMonths(12),
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// For monthly with DayOfMonth set, snap to that day (clamping for short
+    /// months — 31st becomes 28/29/30). Mirrors how most billing systems work.
+    /// </summary>
+    private static DateOnly SnapToDayOfMonth(DateOnly date, int? dayOfMonth)
+    {
+        if (!dayOfMonth.HasValue) return date;
+        var daysInMonth = DateTime.DaysInMonth(date.Year, date.Month);
+        var day = Math.Min(dayOfMonth.Value, daysInMonth);
+        return new DateOnly(date.Year, date.Month, day);
+    }
+
+    private static OccurrenceStatus ClassifyStatus(RecurringPayment payment, DateOnly date, DateOnly today)
+    {
+        var diff = date.DayNumber - today.DayNumber;
+        if (diff < 0) return OccurrenceStatus.Overdue;
+        if (diff == 0) return OccurrenceStatus.DueToday;
+        if (diff <= payment.RemindDaysBefore && payment.RemindDaysBefore > 0) return OccurrenceStatus.DueSoon;
+        return OccurrenceStatus.Pending;
+    }
+
+    // === Aggregates ===
+
+    /// <summary>
+    /// Sum of EffectiveMonthlyCost for all ACTIVE subscriptions, currency-aware
+    /// only if a converter is provided. Without a converter, sums Amount/Months
+    /// in mixed currencies (caller's problem — usually only OK for single-currency).
+    /// </summary>
+    public static decimal MonthlySubscriptionBurden(
+        IEnumerable<RecurringPayment> payments,
+        Func<decimal, string, decimal>? toBase = null)
+    {
+        decimal total = 0;
+        foreach (var p in payments)
+        {
+            if (!p.IsActive || !p.IsSubscription) continue;
+            var months = Math.Max(1, p.BillingIntervalMonths);
+            var monthly = p.Amount / months;
+            total += toBase is null ? monthly : toBase(monthly, p.Currency);
+        }
+        return Math.Round(total, 2);
+    }
+
+    /// <summary>
+    /// Annual savings vs paying every subscription at its ListPriceMonthly.
+    /// Skips subscriptions without a ListPriceMonthly set.
+    /// </summary>
+    public static decimal AnnualSavingsVsMonthly(
+        IEnumerable<RecurringPayment> payments,
+        Func<decimal, string, decimal>? toBase = null)
+    {
+        decimal total = 0;
+        foreach (var p in payments)
+        {
+            if (!p.IsActive || !p.IsSubscription || p.ListPriceMonthly is null) continue;
+            var monthlyEffective = p.Amount / Math.Max(1, p.BillingIntervalMonths);
+            var savedMonthly = p.ListPriceMonthly.Value - monthlyEffective;
+            if (savedMonthly <= 0) continue; // no discount (or worse)
+            var annual = savedMonthly * 12;
+            total += toBase is null ? annual : toBase(annual, p.Currency);
+        }
+        return Math.Round(total, 2);
+    }
+
+    /// <summary>
+    /// Parses the RenewalRemindDaysBefore CSV ("30,7,1") into a sorted set of
+    /// positive ints. Invalid entries are silently dropped (forgiving parser —
+    /// user-edited string, no point throwing).
+    /// </summary>
+    public static IReadOnlyList<int> ParseRemindLadder(string csv)
+    {
+        if (string.IsNullOrWhiteSpace(csv)) return [];
+        var parts = csv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var result = new SortedSet<int>();
+        foreach (var p in parts)
+        {
+            if (int.TryParse(p, out var d) && d > 0) result.Add(d);
+        }
+        return result.ToList();
+    }
+
+    /// <summary>
+    /// Returns the day-count steps in the ladder that match the current
+    /// distance-to-renewal. E.g. ladder=[30,7,1], days=7 → returns [7].
+    /// Used by the reminder service to fire toasts on exact crossings.
+    /// </summary>
+    public static IReadOnlyList<int> StepsCrossingToday(RecurringPayment payment, DateOnly today)
+    {
+        if (!payment.NextRenewalDate.HasValue) return [];
+        var ladder = ParseRemindLadder(payment.RenewalRemindDaysBefore);
+        if (ladder.Count == 0) return [];
+        var diff = payment.NextRenewalDate.Value.DayNumber - today.DayNumber;
+        return ladder.Where(d => d == diff).ToList();
+    }
+}


### PR DESCRIPTION
Pure-logic foundation for everything subscription-related: next-occurrence calculator, status classifier, monthly-burden aggregator, savings calculator, reminder ladder parser.

No DI, no DB, no HTTP - just deterministic functions the VM calls after loading the collection. Trivially testable.

## Service surface

* NextOccurrenceFrom - respects NextRenewalDate, BillingIntervalMonths, DayOfMonth snap
* EnumerateOccurrences - windowed forecast with status classification
* MonthlySubscriptionBurden - sum of effective monthly costs
* AnnualSavingsVsMonthly - Timeweb-tier saving calculator
* ParseRemindLadder - forgiving '30,7,1' CSV parser
* StepsCrossingToday - exact-match ladder step for reminder firing

## Tests

20 new tests, 94 total. Covers: inactive/ended, NextRenewalDate override, monthly snap, yearly billing, status classification, mixed-currency burden, Timeweb savings (10584 vs 980*12 = 1176/yr), CSV edges.

## Next

#82 hooks StepsCrossingToday into MainViewModel._reminderTimer to fire toasts on ladder crossings.