### PR TITLE
v3.37.0: ExchangeRateService - daily CBR fetch + per-date conversion

### DIFF
--- a/DailyPlanner.Tests/ExchangeRateServiceTests.cs
+++ b/DailyPlanner.Tests/ExchangeRateServiceTests.cs
@@ -1,0 +1,145 @@
+using System.Data.Common;
+using System.Text.Json;
+using DailyPlanner.Data;
+using DailyPlanner.Models;
+using DailyPlanner.Services;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace DailyPlanner.Tests;
+
+public class ExchangeRateServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly InMemorySqliteDbFactory _dbFactory;
+    private readonly ExchangeRateService _service;
+
+    public ExchangeRateServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _dbFactory = new InMemorySqliteDbFactory(_connection);
+
+        using (var ctx = _dbFactory.CreateDbContext())
+        {
+            ctx.Database.Migrate();
+        }
+
+        _service = new ExchangeRateService(_dbFactory);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void Seed(string currency, DateOnly date, decimal rate)
+    {
+        using var db = _dbFactory.CreateDbContext();
+        db.ExchangeRates.Add(new ExchangeRate
+        {
+            CurrencyCode = currency,
+            BaseCurrency = ExchangeRateService.BaseCurrency,
+            Date = date,
+            Rate = rate,
+            Source = "test"
+        });
+        db.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetRateAsync_BaseCurrency_ReturnsOne()
+    {
+        var rate = await _service.GetRateAsync("RUB", new DateOnly(2026, 5, 10));
+        rate.Should().Be(1m);
+    }
+
+    [Fact]
+    public async Task GetRateAsync_KnownDate_ReturnsExactRate()
+    {
+        Seed("USD", new DateOnly(2026, 5, 10), 90.5m);
+        var rate = await _service.GetRateAsync("USD", new DateOnly(2026, 5, 10));
+        rate.Should().Be(90.5m);
+    }
+
+    [Fact]
+    public async Task GetRateAsync_MissingForExactDate_FallsBackToMostRecentBefore()
+    {
+        // Saturday — CBR doesn't publish. Friday's rate should be used.
+        Seed("USD", new DateOnly(2026, 5, 8), 90m);  // Friday
+        var rate = await _service.GetRateAsync("USD", new DateOnly(2026, 5, 9));  // Saturday
+        rate.Should().Be(90m);
+    }
+
+    [Fact]
+    public async Task GetRateAsync_NoRateAtAll_ReturnsNull()
+    {
+        var rate = await _service.GetRateAsync("USD", new DateOnly(2026, 5, 10));
+        rate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ConvertToBaseAsync_BaseCurrency_ReturnsAmountUnchanged()
+    {
+        var result = await _service.ConvertToBaseAsync(1000m, "RUB", new DateOnly(2026, 5, 10));
+        result.Should().Be(1000m);
+    }
+
+    [Fact]
+    public async Task ConvertToBaseAsync_AppliesRate()
+    {
+        Seed("USD", new DateOnly(2026, 5, 10), 90.5m);
+        // 20 USD × 90.5 = 1810 RUB
+        var result = await _service.ConvertToBaseAsync(20m, "USD", new DateOnly(2026, 5, 10));
+        result.Should().Be(1810m);
+    }
+
+    [Fact]
+    public async Task ConvertToBaseAsync_NoRate_ReturnsUnconverted()
+    {
+        // Defensive fallback: better wrong total than crash dashboard.
+        var result = await _service.ConvertToBaseAsync(20m, "USD", new DateOnly(2026, 5, 10));
+        result.Should().Be(20m);
+    }
+
+    [Fact]
+    public void CbrDailyResponse_ParsesActualCbrSchema()
+    {
+        const string json = """
+        {
+          "Date": "2026-05-09T11:30:00+03:00",
+          "Valute": {
+            "USD": { "CharCode": "USD", "Nominal": 1, "Value": 74.2963, "Previous": 74.5 },
+            "JPY": { "CharCode": "JPY", "Nominal": 100, "Value": 50.12, "Previous": 50.0 }
+          }
+        }
+        """;
+
+        var parsed = JsonSerializer.Deserialize<ExchangeRateService.CbrDailyResponse>(json);
+
+        parsed.Should().NotBeNull();
+        parsed!.Valute.Should().ContainKey("USD");
+        parsed.Valute!["USD"].Value.Should().Be(74.2963m);
+        parsed.Valute["USD"].Nominal.Should().Be(1);
+        parsed.Valute["JPY"].Nominal.Should().Be(100); // CBR uses Nominal=100 for low-denomination currencies
+    }
+
+    /// <summary>
+    /// Local IDbContextFactory: shares one SqliteConnection across all
+    /// created contexts so all see the same in-memory DB. Same pattern as
+    /// PlannerServiceTestFixture.
+    /// </summary>
+    private sealed class InMemorySqliteDbFactory : IDbContextFactory<PlannerDbContext>
+    {
+        private readonly DbConnection _connection;
+        public InMemorySqliteDbFactory(DbConnection connection) { _connection = connection; }
+        public PlannerDbContext CreateDbContext()
+        {
+            var opts = new DbContextOptionsBuilder<PlannerDbContext>().UseSqlite(_connection).Options;
+            return new PlannerDbContext(opts);
+        }
+    }
+}

--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -180,6 +180,15 @@ public partial class App : Application
             catch (Exception ex)
             {
                 splash?.Close();
+
+            // Fire-and-forget: pull today's currency rates from CBR. Not awaited
+            // because finance aggregates fall back gracefully when rates are
+            // missing (logged + amount returned unconverted).
+            _ = Task.Run(async () =>
+            {
+                try { await ServiceHost.Get<ExchangeRateService>().RefreshAsync(); }
+                catch (Exception ex) { Log.Error("App", $"ExchangeRate refresh failed: {ex.Message}"); }
+            });
                 System.Windows.MessageBox.Show(
                     string.Format(Loc.Get("DbError"), ex.Message),
                     "Daily & Financial Planner",

--- a/DailyPlanner/App.xaml.cs
+++ b/DailyPlanner/App.xaml.cs
@@ -180,15 +180,6 @@ public partial class App : Application
             catch (Exception ex)
             {
                 splash?.Close();
-
-            // Fire-and-forget: pull today's currency rates from CBR. Not awaited
-            // because finance aggregates fall back gracefully when rates are
-            // missing (logged + amount returned unconverted).
-            _ = Task.Run(async () =>
-            {
-                try { await ServiceHost.Get<ExchangeRateService>().RefreshAsync(); }
-                catch (Exception ex) { Log.Error("App", $"ExchangeRate refresh failed: {ex.Message}"); }
-            });
                 System.Windows.MessageBox.Show(
                     string.Format(Loc.Get("DbError"), ex.Message),
                     "Daily & Financial Planner",
@@ -199,6 +190,16 @@ public partial class App : Application
             }
 
             splash?.Close();
+
+            // Fire-and-forget: pull today's currency rates from CBR. Not awaited
+            // because finance aggregates fall back gracefully when rates are
+            // missing (logged + amount returned unconverted), and a slow CBR
+            // response should never delay app launch.
+            _ = Task.Run(async () =>
+            {
+                try { await ServiceHost.Get<ExchangeRateService>().RefreshAsync(); }
+                catch (Exception ex) { Log.Error("App", $"ExchangeRate refresh failed: {ex.Message}"); }
+            });
         }
         catch (Exception ex)
         {

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.36.0</Version>
+    <Version>3.37.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Services/ExchangeRateService.cs
+++ b/DailyPlanner/Services/ExchangeRateService.cs
@@ -1,0 +1,179 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json.Serialization;
+using DailyPlanner.Data;
+using DailyPlanner.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyPlanner.Services;
+
+/// <summary>
+/// Currency conversion against a base currency (RUB). Rates are pulled
+/// daily from the CBR public JSON feed and persisted into the ExchangeRates
+/// table for historical stability — once a transaction captures a rate at
+/// creation time, that rate is frozen on the entry itself
+/// (<see cref="FinanceEntry.ExchangeRateToBase"/>) so the row's RUB value
+/// never drifts as today's rate changes.
+///
+/// Source: https://www.cbr-xml-daily.ru/daily_json.js (no API key, free,
+/// updated by the Central Bank around 11:30 MSK on banking days).
+/// </summary>
+public sealed class ExchangeRateService
+{
+    public const string BaseCurrency = "RUB";
+    private const string CbrUrl = "https://www.cbr-xml-daily.ru/daily_json.js";
+
+    private static readonly HttpClient Client = CreateClient();
+    private readonly IDbContextFactory<PlannerDbContext> _dbFactory;
+
+    public ExchangeRateService(IDbContextFactory<PlannerDbContext> dbFactory)
+    {
+        _dbFactory = dbFactory;
+    }
+
+    private static HttpClient CreateClient()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(15),
+            AutomaticDecompression = System.Net.DecompressionMethods.All
+        };
+        var client = new HttpClient(handler, disposeHandler: true)
+        {
+            Timeout = TimeSpan.FromSeconds(15)
+        };
+        client.DefaultRequestHeaders.UserAgent.ParseAdd($"DailyPlanner/{version}");
+        return client;
+    }
+
+    /// <summary>
+    /// Returns the rate at which 1 unit of <paramref name="fromCurrency"/>
+    /// converts to <see cref="BaseCurrency"/> on <paramref name="date"/>.
+    /// Returns 1 for base-currency conversions. Returns null when no rate
+    /// exists for that exact date — callers should fall back to the nearest
+    /// available rate or skip the conversion.
+    /// </summary>
+    public async Task<decimal?> GetRateAsync(string fromCurrency, DateOnly date, CancellationToken ct = default)
+    {
+        if (string.Equals(fromCurrency, BaseCurrency, StringComparison.OrdinalIgnoreCase)) return 1m;
+
+        await using var db = _dbFactory.CreateDbContext();
+
+        // Exact date first; if missing, take the most recent rate up to that date.
+        // This handles weekends/holidays (CBR doesn't publish, but FinanceEntry can
+        // be backdated to a Saturday).
+        var rate = await db.ExchangeRates
+            .Where(r => r.CurrencyCode == fromCurrency
+                && r.BaseCurrency == BaseCurrency
+                && r.Date <= date)
+            .OrderByDescending(r => r.Date)
+            .Select(r => (decimal?)r.Rate)
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+
+        return rate;
+    }
+
+    /// <summary>
+    /// Converts <paramref name="amount"/> from <paramref name="fromCurrency"/>
+    /// to the base currency using the rate on <paramref name="date"/>.
+    /// If no rate exists, returns the original amount unchanged (logged) —
+    /// better to render a slightly wrong total than crash the dashboard.
+    /// </summary>
+    public async Task<decimal> ConvertToBaseAsync(
+        decimal amount, string fromCurrency, DateOnly date, CancellationToken ct = default)
+    {
+        var rate = await GetRateAsync(fromCurrency, date, ct).ConfigureAwait(false);
+        if (!rate.HasValue)
+        {
+            Log.Error("ExchangeRate",
+                $"No rate found for {fromCurrency} on or before {date:yyyy-MM-dd}. " +
+                $"Returning unconverted amount {amount}.");
+            return amount;
+        }
+        return Math.Round(amount * rate.Value, 2);
+    }
+
+    /// <summary>
+    /// Pulls the current rate snapshot from CBR and upserts each currency
+    /// into the ExchangeRates table. Safe to call concurrently — uses the
+    /// unique index (CurrencyCode, BaseCurrency, Date) to detect duplicates.
+    /// </summary>
+    public async Task<int> RefreshAsync(CancellationToken ct = default)
+    {
+        CbrDailyResponse? data;
+        try
+        {
+            data = await Client.GetFromJsonAsync<CbrDailyResponse>(CbrUrl, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.Error("ExchangeRate", $"CBR fetch failed: {ex.Message}");
+            return 0;
+        }
+
+        if (data is null || data.Valute is null || data.Valute.Count == 0)
+        {
+            Log.Error("ExchangeRate", "CBR response had no Valute data");
+            return 0;
+        }
+
+        var date = DateOnly.FromDateTime(data.Date.UtcDateTime.Date);
+        var upserted = 0;
+
+        await using var db = _dbFactory.CreateDbContext();
+
+        foreach (var (code, info) in data.Valute)
+        {
+            if (info.Nominal == 0) continue;
+            var perUnit = Math.Round(info.Value / info.Nominal, 6);
+
+            var existing = await db.ExchangeRates.FirstOrDefaultAsync(r =>
+                r.CurrencyCode == code &&
+                r.BaseCurrency == BaseCurrency &&
+                r.Date == date, ct).ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                db.ExchangeRates.Add(new ExchangeRate
+                {
+                    CurrencyCode = code,
+                    BaseCurrency = BaseCurrency,
+                    Date = date,
+                    Rate = perUnit,
+                    Source = "cbr.ru"
+                });
+            }
+            else if (existing.Rate != perUnit)
+            {
+                existing.Rate = perUnit;
+            }
+            upserted++;
+        }
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        Log.Error("ExchangeRate", $"Refresh: {upserted} currencies upserted for {date:yyyy-MM-dd}");
+        return upserted;
+    }
+
+    // === CBR API DTOs ===
+
+    /// <summary>CBR daily JSON response top-level shape.</summary>
+    public sealed class CbrDailyResponse
+    {
+        [JsonPropertyName("Date")]
+        public DateTimeOffset Date { get; set; }
+
+        [JsonPropertyName("Valute")]
+        public Dictionary<string, CbrValute>? Valute { get; set; }
+    }
+
+    public sealed class CbrValute
+    {
+        [JsonPropertyName("CharCode")] public string CharCode { get; set; } = string.Empty;
+        [JsonPropertyName("Nominal")] public int Nominal { get; set; } = 1;
+        [JsonPropertyName("Value")] public decimal Value { get; set; }
+        [JsonPropertyName("Previous")] public decimal Previous { get; set; }
+    }
+}

--- a/DailyPlanner/Services/ServiceHost.cs
+++ b/DailyPlanner/Services/ServiceHost.cs
@@ -31,6 +31,7 @@ public static class ServiceHost
         sc.AddSingleton(TimeProvider.System);
         sc.AddSingleton<PlannerService>();
         sc.AddSingleton<TrelloService>();
+        sc.AddSingleton<ExchangeRateService>();
         sc.AddSingleton(_ => new UpdateService("https://github.com/valinerosgordov/DailyPlanner"));
 
         // Main VM is one per window.


### PR DESCRIPTION
Currency conversion against RUB base. Rates pulled daily from CBR public JSON feed and persisted into ExchangeRates table from PR #78. Captured rates freeze on entry creation so historical totals don't drift.

## API

* GetRateAsync(currency, date) - exact-date lookup with weekend/holiday fallback to most recent prior rate. Returns 1 for RUB, null when nothing on or before date.
* ConvertToBaseAsync(amount, currency, date) - applies rate, falls back to unconverted amount when no rate exists (logs loudly).
* RefreshAsync(ct) - upsert today's snapshot from cbr-xml-daily.ru. Handles Nominal!=1 (JPY case).

## Integration

* Registered singleton in ServiceHost
* Fire-and-forget RefreshAsync on startup (not awaited - graceful fallback if CBR slow)

## Tests (8 new, 102 total)

Base currency, exact-date, weekend fallback, missing rate; conversion happy/fallback paths; CBR schema deserialization with Nominal=100 edge case (JPY).

No external HTTP in tests - DB-backed scenarios use seeded ExchangeRates rows, JSON deserialization tested with a string literal of actual CBR shape.