### PR TITLE
v3.39.0: AutoCreate scheduler - daily materialization of pending entries

### DIFF
--- a/DailyPlanner.Tests/FinanceIntegrationTests.cs
+++ b/DailyPlanner.Tests/FinanceIntegrationTests.cs
@@ -324,6 +324,39 @@ public class FinanceIntegrationTests : PlannerServiceTestFixture
     // ─── Financial goals ────────────────────────────────────────────
 
     [Fact]
+    public async Task GenerateRecurringEntries_TimewebYearlyCommitment_CreatesPendingWithCurrency()
+    {
+        var cat = await SeededExpense();
+        await Service.SaveRecurringPaymentAsync(new RecurringPayment
+        {
+            Name = "Timeweb hosting",
+            Amount = 10584m,
+            Currency = "RUB",
+            Type = FinanceEntryType.Expense,
+            CategoryId = cat.Id,
+            Frequency = PaymentFrequency.Yearly,
+            BillingIntervalMonths = 12,
+            StartDate = new DateOnly(2026, 3, 15),
+            IsActive = true,
+            IsSubscription = true,
+            AutoCreate = true
+        });
+
+        // Window covering the March 2026 occurrence
+        await Service.GenerateRecurringEntriesAsync(new DateOnly(2026, 3, 1), new DateOnly(2026, 3, 31));
+
+        var entries = await Service.GetFinanceEntriesAsync(new DateOnly(2026, 3, 1), new DateOnly(2026, 3, 31));
+        var generated = entries.Where(e => e.Description == "Timeweb hosting").ToList();
+
+        generated.Should().HaveCount(1);
+        generated[0].Date.Should().Be(new DateOnly(2026, 3, 15));
+        generated[0].Amount.Should().Be(10584m);
+        generated[0].Currency.Should().Be("RUB");
+        generated[0].IsPaid.Should().BeFalse(); // pending — user confirms
+        generated[0].IsRecurring.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task FinancialGoal_SaveRemoveRoundTrip()
     {
         await Service.SaveFinancialGoalAsync(new FinancialGoal

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon>planner.ico</ApplicationIcon>
     <AssemblyName>DailyPlanner</AssemblyName>
-    <Version>3.38.0</Version>
+    <Version>3.39.0</Version>
     <Authors>DailyPlanner Team</Authors>
     <Description>Daily &amp; Financial Planner вЂ” weekly planner with finance tracker, habits, Pomodoro and analytics</Description>
   </PropertyGroup>

--- a/DailyPlanner/Services/PlannerService.Finance.cs
+++ b/DailyPlanner/Services/PlannerService.Finance.cs
@@ -222,8 +222,21 @@ public sealed partial class PlannerService
         var rp = await db.RecurringPayments.FindAsync([paymentId], ct).ConfigureAwait(false);
         if (rp is not null) { db.RecurringPayments.Remove(rp); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
     }
+    /// <summary>
+    /// Materializes pending FinanceEntry rows for every active AutoCreate
+    /// RecurringPayment that has an occurrence in <paramref name="from"/>..
+    /// <paramref name="to"/>. Each created row is IsPaid=false ("pending")
+    /// so the user confirms with a one-click "Mark Paid" in the UI.
+    ///
+    /// Uses SubscriptionForecastService.EnumerateOccurrences as the single
+    /// source of truth for "when does this recur" — same logic the renewal
+    /// reminder service uses, so a payment that fires a reminder also gets
+    /// a pending entry materialized.
+    /// </summary>
     public async Task GenerateRecurringEntriesAsync(DateOnly from, DateOnly to, CancellationToken ct = default)
     {
+        if (to < from) return;
+
         await using var db = _dbFactory.CreateDbContext();
         var payments = await db.RecurringPayments
             .Where(rp => rp.IsActive && rp.AutoCreate && rp.StartDate <= to && (rp.EndDate == null || rp.EndDate >= from))
@@ -235,36 +248,23 @@ public sealed partial class PlannerService
             .ToListAsync(ct).ConfigureAwait(false))
             .ToHashSet();
 
+        var window = to.DayNumber - from.DayNumber + 1;
         var newEntries = new List<FinanceEntry>();
 
         foreach (var rp in payments)
         {
-            for (var date = from; date <= to; date = date.AddDays(1))
+            foreach (var occ in SubscriptionForecastService.EnumerateOccurrences(rp, from, window))
             {
-                if (date < rp.StartDate || (rp.EndDate is not null && date > rp.EndDate)) continue;
-
-                var match = rp.Frequency switch
-                {
-                    PaymentFrequency.Monthly => rp.DayOfMonth is not null && date.Day == rp.DayOfMonth,
-                    PaymentFrequency.Weekly => rp.DayOfWeek is not null && date.DayOfWeek == rp.DayOfWeek,
-                    PaymentFrequency.Biweekly => rp.DayOfWeek is not null && date.DayOfWeek == rp.DayOfWeek
-                        && Math.Abs(date.ToDateTime(TimeOnly.MinValue).Subtract(rp.StartDate.ToDateTime(TimeOnly.MinValue)).Days) % 14 == 0,
-                    PaymentFrequency.Quarterly => rp.DayOfMonth is not null && date.Day == rp.DayOfMonth
-                        && ((date.Year - rp.StartDate.Year) * 12 + date.Month - rp.StartDate.Month) % 3 == 0,
-                    PaymentFrequency.Yearly => rp.DayOfMonth is not null && date.Day == rp.DayOfMonth
-                        && date.Month == rp.StartDate.Month,
-                    _ => false
-                };
-
-                if (!match) continue;
-                if (!existingKeys.Add(new { RecurringPaymentId = (int?)rp.Id, Date = date })) continue;
+                if (occ.Date > to) break;
+                if (!existingKeys.Add(new { RecurringPaymentId = (int?)rp.Id, Date = occ.Date })) continue;
 
                 newEntries.Add(new FinanceEntry
                 {
-                    Date = date,
+                    Date = occ.Date,
                     CategoryId = rp.CategoryId,
                     Type = rp.Type,
                     Amount = rp.Amount,
+                    Currency = rp.Currency,
                     Description = rp.Name,
                     IsRecurring = true,
                     RecurringPaymentId = rp.Id,

--- a/DailyPlanner/ViewModels/MainViewModel.cs
+++ b/DailyPlanner/ViewModels/MainViewModel.cs
@@ -530,6 +530,7 @@ public sealed partial class MainViewModel : ObservableObject
         await LoadMeetingsAsync();
 
         StartReminderCheck();
+        _ = EnsureAutoCreateEntriesAsync();
         CheckForUpdatesAsync().FireAndForget("UpdateCheck");
         AutoSyncTrelloAsync().FireAndForget("TrelloAutoSync");
     }
@@ -614,6 +615,26 @@ public sealed partial class MainViewModel : ObservableObject
 
     private readonly HashSet<string> _firedReminders = [];
     private DateOnly _lastReminderDate = DateOnly.FromDateTime(DateTime.Today);
+    private DateOnly _lastAutoCreateDate = DateOnly.MinValue;
+
+    /// <summary>
+    /// Runs AutoCreate at most once per calendar day. Window [today-7..today+30]
+    /// catches anything missed (app closed when due date passed) and pre-creates
+    /// the next month so the calendar strip always has data. Each row materializes
+    /// with IsPaid=false ('pending') — the UI shows them with a 'Mark paid' button.
+    /// </summary>
+    private async Task EnsureAutoCreateEntriesAsync()
+    {
+        try
+        {
+            var today = DateOnly.FromDateTime(_time.GetLocalNow().LocalDateTime);
+            if (today == _lastAutoCreateDate) return;
+            _lastAutoCreateDate = today;
+
+            await _service.GenerateRecurringEntriesAsync(today.AddDays(-7), today.AddDays(30));
+        }
+        catch (Exception ex) { Log.Error("MainVM", $"AutoCreate failed: {ex.Message}"); }
+    }
 
     private void CheckReminders()
     {
@@ -646,6 +667,7 @@ public sealed partial class MainViewModel : ObservableObject
         }
 
         CheckMeetingReminders();
+        _ = EnsureAutoCreateEntriesAsync();
         _ = CheckSubscriptionRemindersAsync();
     }
 


### PR DESCRIPTION
Hooks AutoCreate=true RecurringPayments into the existing _reminderTimer so each subscription's next occurrence materializes as Pending FinanceEntry (IsPaid=false) ahead of time. User confirms with one-click 'Mark Paid' once their bank actually charges.

## What changed

**PlannerService.Finance.cs - GenerateRecurringEntriesAsync refactor**: old hand-coded switch over PaymentFrequency didn't understand BillingIntervalMonths > 1, so Timeweb-yearly never materialized. New logic delegates to SubscriptionForecastService.EnumerateOccurrences (same source of truth the reminder service uses). Also captures Currency from parent RecurringPayment.

**MainViewModel.cs - daily scheduler**: new EnsureAutoCreateEntriesAsync with _lastAutoCreateDate guard. Window [today-7..today+30]. Runs on startup + from CheckReminders Tick (covers midnight rollover).

## Tests

103 pass (102 prior + 1 new: Timeweb-yearly materializes correctly with currency captured). All 4 existing integration tests still pass - behaviour-compatible refactor on cases the old switch handled.

## Behaviour

At most one GenerateRecurringEntries run per calendar day (cheap re-runs would be idempotent anyway due to the existing dedup, but no point spamming).

Errors swallowed and logged - never crash UI thread.