### PR TITLE
Debt auto-settle, per-entry currency UI, honest finance export

### DIFF
--- a/DailyPlanner.Tests/DebtSettleTests.cs
+++ b/DailyPlanner.Tests/DebtSettleTests.cs
@@ -1,0 +1,77 @@
+using DailyPlanner.Models;
+using FluentAssertions;
+
+namespace DailyPlanner.Tests;
+
+/// <summary>
+/// "Settled" derives from payments: a fully paid debt closes itself, removing a
+/// payment below the full amount reopens it. IsSettled used to be an unrelated
+/// manual flag — fully paid debts stayed in the active (and overdue) list.
+/// </summary>
+public class DebtSettleTests : PlannerServiceTestFixture
+{
+    private async Task<Debt> CreateDebtAsync(decimal amount)
+    {
+        var debt = new Debt
+        {
+            PersonName = "Иван",
+            Direction = DebtDirection.Lent,
+            Amount = amount,
+            CreatedDate = DateOnly.FromDateTime(DateTime.Today)
+        };
+        await Service.SaveDebtAsync(debt);
+        return debt;
+    }
+
+    [Fact]
+    public async Task AddPayment_CoveringFullAmount_AutoSettlesTheDebt()
+    {
+        var debt = await CreateDebtAsync(1000m);
+
+        await Service.AddDebtPaymentAsync(new DebtPayment
+        {
+            DebtId = debt.Id,
+            Amount = 1000m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        var settled = (await Service.GetDebtsAsync(includeSettled: true)).Single(d => d.Id == debt.Id);
+        settled.IsSettled.Should().BeTrue("a fully paid debt must not hang in the active list");
+        settled.SettledDate.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AddPayment_Partial_KeepsDebtActive()
+    {
+        var debt = await CreateDebtAsync(1000m);
+
+        await Service.AddDebtPaymentAsync(new DebtPayment
+        {
+            DebtId = debt.Id,
+            Amount = 400m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        });
+
+        var active = (await Service.GetDebtsAsync()).Single(d => d.Id == debt.Id);
+        active.IsSettled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RemovePayment_DroppingBelowFullAmount_ReopensTheDebt()
+    {
+        var debt = await CreateDebtAsync(1000m);
+        var payment = new DebtPayment
+        {
+            DebtId = debt.Id,
+            Amount = 1000m,
+            Date = DateOnly.FromDateTime(DateTime.Today)
+        };
+        await Service.AddDebtPaymentAsync(payment);
+
+        await Service.RemoveDebtPaymentAsync(payment.Id);
+
+        var reopened = (await Service.GetDebtsAsync()).Single(d => d.Id == debt.Id);
+        reopened.IsSettled.Should().BeFalse("payments no longer cover the amount");
+        reopened.SettledDate.Should().BeNull();
+    }
+}

--- a/DailyPlanner/Services/ExportService.cs
+++ b/DailyPlanner/Services/ExportService.cs
@@ -196,44 +196,20 @@ public static class ExportService
             ws.Cell(row, 1).Value = Loc.Get("Income");
             ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
             row++;
-            ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
-            ws.Cell(row, 2).Value = Loc.Get("FinanceDescription");
-            ws.Cell(row, 3).Value = Loc.Get("Amount");
-            ws.Cell(row, 4).Value = Loc.Get("Date");
-            ws.Range(row, 1, row, 4).Style.Font.SetBold(true);
-            row++;
+            row = WriteEntryHeader(ws, row);
 
             foreach (var e in income)
-            {
-                ws.Cell(row, 1).Value = EscapeForExcel($"{e.CategoryIcon} {e.CategoryName}");
-                ws.Cell(row, 2).Value = EscapeForExcel(e.Description);
-                ws.Cell(row, 3).Value = e.Amount;
-                ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
-                ws.Cell(row, 4).Value = e.DisplayDate;
-                row++;
-            }
+                row = WriteEntryRow(ws, row, e);
 
             // Expense entries
             row++;
             ws.Cell(row, 1).Value = Loc.Get("Expenses");
             ws.Cell(row, 1).Style.Font.SetBold(true).Font.SetFontSize(12);
             row++;
-            ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
-            ws.Cell(row, 2).Value = Loc.Get("FinanceDescription");
-            ws.Cell(row, 3).Value = Loc.Get("Amount");
-            ws.Cell(row, 4).Value = Loc.Get("Date");
-            ws.Range(row, 1, row, 4).Style.Font.SetBold(true);
-            row++;
+            row = WriteEntryHeader(ws, row);
 
             foreach (var e in expenses)
-            {
-                ws.Cell(row, 1).Value = EscapeForExcel($"{e.CategoryIcon} {e.CategoryName}");
-                ws.Cell(row, 2).Value = EscapeForExcel(e.Description);
-                ws.Cell(row, 3).Value = e.Amount;
-                ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
-                ws.Cell(row, 4).Value = e.DisplayDate;
-                row++;
-            }
+                row = WriteEntryRow(ws, row, e);
 
             // Budgets
             if (budgets.Count > 0)
@@ -288,5 +264,32 @@ public static class ExportService
             Log.Error("ExportService", $"Finance export failed: {ex.Message}");
             return false;
         }
+    }
+
+    private static int WriteEntryHeader(IXLWorksheet ws, int row)
+    {
+        ws.Cell(row, 1).Value = Loc.Get("CtxCategory");
+        ws.Cell(row, 2).Value = Loc.Get("FinanceDescription");
+        ws.Cell(row, 3).Value = Loc.Get("Amount");
+        ws.Cell(row, 4).Value = Loc.Get("FinCurrency");
+        ws.Cell(row, 5).Value = "RUB";
+        ws.Cell(row, 6).Value = Loc.Get("Date");
+        ws.Range(row, 1, row, 6).Style.Font.SetBold(true);
+        return row + 1;
+    }
+
+    // Original amount + currency + the stamped base value — the summary totals
+    // are base-currency sums, so the per-row RUB column makes them reconcilable.
+    private static int WriteEntryRow(IXLWorksheet ws, int row, FinanceEntryViewModel e)
+    {
+        ws.Cell(row, 1).Value = EscapeForExcel($"{e.CategoryIcon} {e.CategoryName}");
+        ws.Cell(row, 2).Value = EscapeForExcel(e.Description);
+        ws.Cell(row, 3).Value = e.Amount;
+        ws.Cell(row, 3).Style.NumberFormat.Format = "#,##0.00";
+        ws.Cell(row, 4).Value = e.Currency;
+        ws.Cell(row, 5).Value = e.Model.BaseAmount;
+        ws.Cell(row, 5).Style.NumberFormat.Format = "#,##0.00";
+        ws.Cell(row, 6).Value = e.DisplayDate;
+        return row + 1;
     }
 }

--- a/DailyPlanner/Services/Loc.En.cs
+++ b/DailyPlanner/Services/Loc.En.cs
@@ -189,6 +189,7 @@ internal static class LocEnStrings
         ["RestoreSuccess"] = "Database restored successfully",
         ["RestoreError"] = "Error restoring database",
         ["RestoreInvalidDb"] = "File is not a valid SQLite database",
+        ["FinCurrency"] = "Currency",
         ["CopyTitle"] = "Copy",
         ["CopySuccess"] = "Last week's structure copied",
         ["Reminder"] = "Reminder",

--- a/DailyPlanner/Services/Loc.Es.cs
+++ b/DailyPlanner/Services/Loc.Es.cs
@@ -189,6 +189,7 @@ internal static class LocEsStrings
         ["RestoreSuccess"] = "Base de datos restaurada correctamente",
         ["RestoreError"] = "Error al restaurar la base de datos",
         ["RestoreInvalidDb"] = "El archivo no es una base de datos SQLite válida",
+        ["FinCurrency"] = "Moneda",
         ["CopyTitle"] = "Copiar",
         ["CopySuccess"] = "Estructura de la semana pasada copiada",
         ["Reminder"] = "Recordatorio",

--- a/DailyPlanner/Services/Loc.Fr.cs
+++ b/DailyPlanner/Services/Loc.Fr.cs
@@ -189,6 +189,7 @@ internal static class LocFrStrings
         ["RestoreSuccess"] = "Base de données restaurée avec succès",
         ["RestoreError"] = "Erreur lors de la restauration",
         ["RestoreInvalidDb"] = "Le fichier n'est pas une base de données SQLite valide",
+        ["FinCurrency"] = "Devise",
         ["CopyTitle"] = "Copier",
         ["CopySuccess"] = "Structure de la semaine dernière copiée",
         ["Reminder"] = "Rappel",

--- a/DailyPlanner/Services/Loc.Ru.cs
+++ b/DailyPlanner/Services/Loc.Ru.cs
@@ -205,6 +205,7 @@ internal static class LocRuStrings
         ["RestoreSuccess"] = "База данных успешно восстановлена",
         ["RestoreError"] = "Ошибка при восстановлении",
         ["RestoreInvalidDb"] = "Файл не является базой данных SQLite",
+        ["FinCurrency"] = "Валюта",
         ["CopyTitle"] = "Копирование",
         ["CopySuccess"] = "Структура прошлой недели скопирована",
         ["Reminder"] = "Напоминание",

--- a/DailyPlanner/Services/PlannerService.Debt.cs
+++ b/DailyPlanner/Services/PlannerService.Debt.cs
@@ -43,11 +43,37 @@ public sealed partial class PlannerService
         await using var db = _dbFactory.CreateDbContext();
         db.DebtPayments.Add(payment);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        await RecalcSettledStateAsync(db, payment.DebtId, ct).ConfigureAwait(false);
     }
     public async Task RemoveDebtPaymentAsync(int paymentId, CancellationToken ct = default)
     {
         await using var db = _dbFactory.CreateDbContext();
         var p = await db.DebtPayments.FindAsync([paymentId], ct).ConfigureAwait(false);
-        if (p is not null) { db.DebtPayments.Remove(p); await db.SaveChangesAsync(ct).ConfigureAwait(false); }
+        if (p is null) return;
+        var debtId = p.DebtId;
+        db.DebtPayments.Remove(p);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        await RecalcSettledStateAsync(db, debtId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Payments are the source of truth for "settled": a fully paid debt closes
+    /// itself, dropping below the full amount reopens it. IsSettled used to be an
+    /// independent flag — a fully paid debt could hang in the active list forever.
+    /// The manual toggle still works for write-offs; it is only revisited here,
+    /// when payments actually change.
+    /// </summary>
+    private static async Task RecalcSettledStateAsync(PlannerDbContext db, int debtId, CancellationToken ct)
+    {
+        var debt = await db.Debts.Include(d => d.Payments)
+            .FirstOrDefaultAsync(d => d.Id == debtId, ct).ConfigureAwait(false);
+        if (debt is null || debt.Amount <= 0) return;
+
+        var fullyPaid = debt.Payments.Sum(p => p.Amount) >= debt.Amount;
+        if (fullyPaid == debt.IsSettled) return;
+
+        debt.IsSettled = fullyPaid;
+        debt.SettledDate = fullyPaid ? DateOnly.FromDateTime(DateTime.Today) : null;
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 }

--- a/DailyPlanner/ViewModels/DebtViewModel.cs
+++ b/DailyPlanner/ViewModels/DebtViewModel.cs
@@ -82,6 +82,12 @@ public sealed partial class DebtViewModel : ObservableObject
         OnPropertyChanged(nameof(PaidAmount));
         OnPropertyChanged(nameof(RemainingAmount));
         OnPropertyChanged(nameof(ProgressPercent));
+
+        // Mirror of PlannerService.RecalcSettledStateAsync: settled state follows
+        // the payments. Runs only when payments/amount change, so a manual
+        // write-off (no payments) is left alone until the numbers move.
+        var fullyPaid = Amount > 0 && RemainingAmount <= 0;
+        if (fullyPaid != IsSettled) IsSettled = fullyPaid;
     }
 
     private void Save()

--- a/DailyPlanner/ViewModels/FinanceEntryViewModel.cs
+++ b/DailyPlanner/ViewModels/FinanceEntryViewModel.cs
@@ -48,6 +48,44 @@ public sealed partial class FinanceEntryViewModel : ObservableObject
     public bool IsSplit => _model.ParentEntryId is not null;
     public bool HasSplits => SplitEntries.Count > 0;
 
+    /// <summary>Shortlist for the per-entry currency picker; base currency first.</summary>
+    public static IReadOnlyList<string> CurrencyOptions { get; } =
+        ["RUB", "USD", "EUR", "GBP", "CNY", "TRY", "KZT", "AMD", "GEL", "AED"];
+
+    public string Currency
+    {
+        get => _model.Currency;
+        set
+        {
+            if (string.IsNullOrEmpty(value) || _model.Currency == value) return;
+            _model.Currency = value;
+            OnPropertyChanged();
+            _ = SaveCurrencyAsync();
+        }
+    }
+
+    public bool IsForeignCurrency => !string.IsNullOrEmpty(_model.Currency)
+        && !string.Equals(_model.Currency, ExchangeRateService.BaseCurrency, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>"≈ 1 810 ₽" for foreign-currency rows; empty for base currency.</summary>
+    public string BaseAmountHint => IsForeignCurrency ? $"≈ {_model.BaseAmount:N0} ₽" : string.Empty;
+
+    // Not debounced: SaveFinanceEntryAsync re-stamps AmountInBaseCurrency on this
+    // very instance, and the hint must refresh only after that happens.
+    private async Task SaveCurrencyAsync()
+    {
+        try
+        {
+            await _service.SaveFinanceEntryAsync(_model);
+        }
+        catch (Exception ex)
+        {
+            Log.Error("FinanceEntryVM", $"Currency save failed: {ex.Message}");
+        }
+        OnPropertyChanged(nameof(IsForeignCurrency));
+        OnPropertyChanged(nameof(BaseAmountHint));
+    }
+
     public ObservableCollection<FinanceEntryViewModel> SplitEntries { get; } = [];
 
     public string DisplayAmount => Type == FinanceEntryType.Income

--- a/DailyPlanner/Views/FinancePage.xaml
+++ b/DailyPlanner/Views/FinancePage.xaml
@@ -4,6 +4,7 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:conv="clr-namespace:DailyPlanner.Converters"
       xmlns:svc="clr-namespace:DailyPlanner.Services"
+      xmlns:vm="clr-namespace:DailyPlanner.ViewModels"
       Foreground="{DynamicResource TextPrimaryBrush}">
 
     <Page.Resources>
@@ -338,11 +339,15 @@
                                                        DockPanel.Dock="Right" Padding="4" VerticalAlignment="Center"
                                                        Command="{Binding DataContext.RemoveIncomeEntryCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                        CommandParameter="{Binding}"/>
-                                            <TextBox DockPanel.Dock="Right"
-                                                     Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
-                                                     Style="{StaticResource FinanceAmountTextBox}"
-                                                     Foreground="{DynamicResource SuccessBrush}"
-                                                     VerticalAlignment="Center" Margin="8,0"/>
+                                            <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="8,0">
+                                                <TextBox Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                         Style="{StaticResource FinanceAmountTextBox}"
+                                                         Foreground="{DynamicResource SuccessBrush}"/>
+                                                <TextBlock Text="{Binding BaseAmountHint}" FontSize="10"
+                                                           HorizontalAlignment="Right"
+                                                           Foreground="{DynamicResource MutedBrush}"
+                                                           Visibility="{Binding IsForeignCurrency, Converter={StaticResource VisConv}}"/>
+                                            </StackPanel>
                                             <StackPanel VerticalAlignment="Center">
                                                 <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                                                          Style="{StaticResource FinanceInlineTextBox}"/>
@@ -355,6 +360,10 @@
                                                               Background="Transparent" BorderThickness="0"/>
                                                     <DatePicker SelectedDate="{Binding Date, Converter={conv:DateOnlyToDateTimeConverter}}"
                                                                 Style="{StaticResource CompactDatePicker}" Margin="8,0,0,0"/>
+                                                    <ComboBox ItemsSource="{x:Static vm:FinanceEntryViewModel.CurrencyOptions}"
+                                                              SelectedItem="{Binding Currency}"
+                                                              FontSize="11" Padding="4,1" Margin="8,0,0,0"
+                                                              Background="Transparent" BorderThickness="0"/>
                                                 </StackPanel>
                                             </StackPanel>
                                         </DockPanel>
@@ -445,11 +454,15 @@
                                                        DockPanel.Dock="Right" Padding="4" VerticalAlignment="Center"
                                                        Command="{Binding DataContext.RemoveExpenseEntryCommand, RelativeSource={RelativeSource AncestorType=Page}}"
                                                        CommandParameter="{Binding}"/>
-                                            <TextBox DockPanel.Dock="Right"
-                                                     Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
-                                                     Style="{StaticResource FinanceAmountTextBox}"
-                                                     Foreground="{DynamicResource DangerBrush}"
-                                                     VerticalAlignment="Center" Margin="8,0"/>
+                                            <StackPanel DockPanel.Dock="Right" VerticalAlignment="Center" Margin="8,0">
+                                                <TextBox Text="{Binding Amount, Converter={StaticResource CurrencyConv}, UpdateSourceTrigger=LostFocus}"
+                                                         Style="{StaticResource FinanceAmountTextBox}"
+                                                         Foreground="{DynamicResource DangerBrush}"/>
+                                                <TextBlock Text="{Binding BaseAmountHint}" FontSize="10"
+                                                           HorizontalAlignment="Right"
+                                                           Foreground="{DynamicResource MutedBrush}"
+                                                           Visibility="{Binding IsForeignCurrency, Converter={StaticResource VisConv}}"/>
+                                            </StackPanel>
                                             <StackPanel VerticalAlignment="Center">
                                                 <TextBox Text="{Binding Description, UpdateSourceTrigger=PropertyChanged}"
                                                          Style="{StaticResource FinanceInlineTextBox}"/>
@@ -462,6 +475,10 @@
                                                               Background="Transparent" BorderThickness="0"/>
                                                     <DatePicker SelectedDate="{Binding Date, Converter={conv:DateOnlyToDateTimeConverter}}"
                                                                 Style="{StaticResource CompactDatePicker}" Margin="8,0,0,0"/>
+                                                    <ComboBox ItemsSource="{x:Static vm:FinanceEntryViewModel.CurrencyOptions}"
+                                                              SelectedItem="{Binding Currency}"
+                                                              FontSize="11" Padding="4,1" Margin="8,0,0,0"
+                                                              Background="Transparent" BorderThickness="0"/>
                                                 </StackPanel>
                                             </StackPanel>
                                         </DockPanel>
@@ -768,7 +785,7 @@
             </StackPanel>
 
             <!-- ═══════════════ TAB 3: Recurring Payments ═══════════════ -->
-            <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=3}">
+            <StackPanel Visibility="{Binding SelectedTabIndex, Converter={conv:IntToVisibilityConverter}, ConverterParameter=3}">
 
                 <!-- Subscription summary cards (added 2026-05 — backend in PRs #78-83) -->
                 <UniformGrid Rows="1" Columns="4" Margin="0,0,0,12">


### PR DESCRIPTION
Items 2+6+7 from the post-audit roadmap: settled state derives from payments; per-entry currency picker with base-amount hint; export gains Currency/RUB columns. 123 tests green.