### PR TITLE
Two-way Trello sync: archive card on task completion

### DIFF
--- a/DailyPlanner.Tests/TrelloTwoWayTests.cs
+++ b/DailyPlanner.Tests/TrelloTwoWayTests.cs
@@ -1,0 +1,47 @@
+using DailyPlanner.Models;
+using DailyPlanner.Services;
+using FluentAssertions;
+
+namespace DailyPlanner.Tests;
+
+public class TrelloTwoWayTests : PlannerServiceTestFixture
+{
+    [Fact]
+    public async Task TrelloSettings_PushCompletions_RoundTrips()
+    {
+        var settings = await Service.GetTrelloSettingsAsync();
+        settings.PushCompletions = true;
+        settings.IsEnabled = true;
+        await Service.SaveTrelloSettingsAsync(settings);
+
+        var reloaded = await Service.GetTrelloSettingsAsync();
+        reloaded.PushCompletions.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PushCompletedToTrello_Disabled_DoesNothing()
+    {
+        // PushCompletions defaults to false (opt-in) — the push pass must be a
+        // no-op and, critically, must not touch the network at all.
+        var pushed = await Service.PushCompletedToTrelloAsync(new TrelloService());
+        pushed.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CompletedTrelloTask_IsQueuedForPush_UntilStamped()
+    {
+        var week = await Service.GetOrCreateWeekAsync(new DateOnly(2026, 4, 13));
+        var task = week.Days[0].Tasks[0];
+        task.Text = "Trello task";
+        task.ExternalId = "card-1";
+        task.IsCompleted = true;
+        await Service.SaveTaskAsync(task);
+
+        await using var db = CreateContext();
+        var pending = db.DailyTasks
+            .Where(t => t.ExternalId != null && t.IsCompleted && t.ExternalClosedUtc == null)
+            .ToList();
+        pending.Should().ContainSingle(t => t.ExternalId == "card-1",
+            "a completed Trello task without a push stamp is exactly what the push pass picks up");
+    }
+}

--- a/DailyPlanner/Migrations/20260717005800_TrelloTwoWaySync.Designer.cs
+++ b/DailyPlanner/Migrations/20260717005800_TrelloTwoWaySync.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DailyPlanner.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DailyPlanner.Migrations
 {
     [DbContext(typeof(PlannerDbContext))]
-    partial class PlannerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717005800_TrelloTwoWaySync")]
+    partial class TrelloTwoWaySync
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/DailyPlanner/Migrations/20260717005800_TrelloTwoWaySync.cs
+++ b/DailyPlanner/Migrations/20260717005800_TrelloTwoWaySync.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DailyPlanner.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrelloTwoWaySync : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "PushCompletions",
+                table: "TrelloSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ExternalClosedUtc",
+                table: "DailyTasks",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PushCompletions",
+                table: "TrelloSettings");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalClosedUtc",
+                table: "DailyTasks");
+        }
+    }
+}

--- a/DailyPlanner/Models/DailyTask.cs
+++ b/DailyPlanner/Models/DailyTask.cs
@@ -17,6 +17,13 @@ public sealed class DailyTask
     public DateOnly? Deadline { get; set; }
     public string? ExternalId { get; set; }
 
+    /// <summary>
+    /// When the completion of this task was pushed to Trello (card archived).
+    /// Null = not pushed yet (retried on the next push pass) or not a Trello task.
+    /// Cleared when the task is un-completed and the card gets un-archived.
+    /// </summary>
+    public DateTime? ExternalClosedUtc { get; set; }
+
     public DailyPlan? DailyPlan { get; set; }
     public DailyTask? ParentTask { get; set; }
     public List<DailyTask> SubTasks { get; set; } = [];

--- a/DailyPlanner/Models/TrelloSettings.cs
+++ b/DailyPlanner/Models/TrelloSettings.cs
@@ -8,5 +8,9 @@ public sealed class TrelloSettings
     public string ListName { get; set; } = "В работе";
     public bool IsEnabled { get; set; }
     public bool AutoSyncOnStartup { get; set; }
+
+    /// <summary>Two-way sync: archive the Trello card when its task is completed. Opt-in.</summary>
+    public bool PushCompletions { get; set; }
+
     public DateTime? LastSyncUtc { get; set; }
 }

--- a/DailyPlanner/Services/Loc.En.cs
+++ b/DailyPlanner/Services/Loc.En.cs
@@ -453,6 +453,7 @@ internal static class LocEnStrings
         ["TrelloDesc"] = "Pulls cards from the specified list into the planner inbox.",
         ["TrelloApiKey"] = "API Key",
         ["TrelloToken"] = "Token",
+        ["TrelloPushCompletions"] = "Archive Trello card when task is completed",
         ["TrelloListName"] = "List name (e.g. \"Doing\")",
         ["TrelloHelp"] = "Get key at https://trello.com/app-key — same page has a \"Token\" button.",
         ["TestConnection"] = "Test connection",

--- a/DailyPlanner/Services/Loc.Es.cs
+++ b/DailyPlanner/Services/Loc.Es.cs
@@ -453,6 +453,7 @@ internal static class LocEsStrings
         ["TrelloDesc"] = "Importa tarjetas de la lista indicada a la bandeja de entrada.",
         ["TrelloApiKey"] = "Clave API",
         ["TrelloToken"] = "Token",
+        ["TrelloPushCompletions"] = "Archivar la tarjeta de Trello al completar la tarea",
         ["TrelloListName"] = "Nombre de lista (p.ej. \"En proceso\")",
         ["TrelloHelp"] = "Obtén la clave en https://trello.com/app-key — en la misma página hay un botón \"Token\".",
         ["TestConnection"] = "Probar conexión",

--- a/DailyPlanner/Services/Loc.Fr.cs
+++ b/DailyPlanner/Services/Loc.Fr.cs
@@ -453,6 +453,7 @@ internal static class LocFrStrings
         ["TrelloDesc"] = "Importe les cartes de la liste indiquée dans la boîte de réception.",
         ["TrelloApiKey"] = "Clé API",
         ["TrelloToken"] = "Jeton",
+        ["TrelloPushCompletions"] = "Archiver la carte Trello quand la tâche est terminée",
         ["TrelloListName"] = "Nom de la liste (ex. «En cours»)",
         ["TrelloHelp"] = "Obtenez la clé sur https://trello.com/app-key — le bouton «Token» est sur la même page.",
         ["TestConnection"] = "Tester la connexion",

--- a/DailyPlanner/Services/Loc.Ru.cs
+++ b/DailyPlanner/Services/Loc.Ru.cs
@@ -486,6 +486,7 @@ internal static class LocRuStrings
         ["TrelloDesc"] = "Подтягивает карточки из указанного списка во входящие планера.",
         ["TrelloApiKey"] = "API ключ",
         ["TrelloToken"] = "Токен",
+        ["TrelloPushCompletions"] = "Архивировать карточку Trello при выполнении задачи",
         ["TrelloListName"] = "Название списка (например, «В работе»)",
         ["TrelloHelp"] = "Получить ключ: https://trello.com/app-key — там же создаётся токен по кнопке «Token».",
         ["TestConnection"] = "Проверить соединение",

--- a/DailyPlanner/Services/PlannerService.Inbox.cs
+++ b/DailyPlanner/Services/PlannerService.Inbox.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using DailyPlanner.Data;
 using DailyPlanner.Models;
 using Microsoft.EntityFrameworkCore;
@@ -184,8 +185,70 @@ public sealed partial class PlannerService
                 tracked.LastSyncUtc = DateTime.UtcNow;
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);
             }
+
+            // Push side of the two-way sync rides along with every pull.
+            await PushCompletedToTrelloAsync(trello, ct).ConfigureAwait(false);
+
             return added;
         }
         finally { _trelloSyncGate.Release(); }
+    }
+
+    /// <summary>
+    /// Two-way sync, push side: archives Trello cards whose tasks are completed
+    /// and un-archives them when a task is un-completed. Success is stamped on
+    /// the task (ExternalClosedUtc), so each transition is pushed exactly once
+    /// and failures retry automatically on the next pass.
+    /// </summary>
+    public async Task<int> PushCompletedToTrelloAsync(TrelloService trello, CancellationToken ct = default)
+    {
+        var settings = await GetTrelloSettingsAsync(ct).ConfigureAwait(false);
+        if (!settings.IsEnabled || !settings.PushCompletions
+            || string.IsNullOrWhiteSpace(settings.ApiKey) || string.IsNullOrWhiteSpace(settings.Token))
+            return 0;
+
+        await using var db = _dbFactory.CreateDbContext();
+        var toClose = await db.DailyTasks
+            .Where(t => t.ExternalId != null && t.IsCompleted && t.ExternalClosedUtc == null)
+            .ToListAsync(ct).ConfigureAwait(false);
+        var toReopen = await db.DailyTasks
+            .Where(t => t.ExternalId != null && !t.IsCompleted && t.ExternalClosedUtc != null)
+            .ToListAsync(ct).ConfigureAwait(false);
+        if (toClose.Count == 0 && toReopen.Count == 0) return 0;
+
+        var pushed = 0;
+        try
+        {
+            foreach (var task in toClose)
+            {
+                if (!await trello.SetCardClosedAsync(task.ExternalId!, true, settings.ApiKey, settings.Token, ct).ConfigureAwait(false))
+                    continue;
+                task.ExternalClosedUtc = DateTime.UtcNow;
+                pushed++;
+            }
+            foreach (var task in toReopen)
+            {
+                if (!await trello.SetCardClosedAsync(task.ExternalId!, false, settings.ApiKey, settings.Token, ct).ConfigureAwait(false))
+                    continue;
+                task.ExternalClosedUtc = null;
+                pushed++;
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            // Offline is normal for this app — save what got through, retry later.
+            Log.Warn("TrelloPush", $"Push interrupted: {ex.Message}");
+        }
+        catch (TaskCanceledException)
+        {
+            Log.Warn("TrelloPush", "Push timed out; will retry on the next pass.");
+        }
+
+        if (pushed > 0)
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            Log.Info("TrelloPush", $"Pushed {pushed} completion state(s) to Trello.");
+        }
+        return pushed;
     }
 }

--- a/DailyPlanner/Services/TrelloService.cs
+++ b/DailyPlanner/Services/TrelloService.cs
@@ -37,8 +37,11 @@ public sealed class TrelloService
     /// access logs, or referer headers from any redirect).
     /// </summary>
     private static HttpRequestMessage AuthorizedGet(string url, string apiKey, string token)
+        => Authorized(HttpMethod.Get, url, apiKey, token);
+
+    private static HttpRequestMessage Authorized(HttpMethod method, string url, string apiKey, string token)
     {
-        var req = new HttpRequestMessage(HttpMethod.Get, url);
+        var req = new HttpRequestMessage(method, url);
         req.Headers.Authorization = new AuthenticationHeaderValue(
             "OAuth",
             $"oauth_consumer_key=\"{apiKey}\", oauth_token=\"{token}\"");
@@ -102,6 +105,19 @@ public sealed class TrelloService
         response.EnsureSuccessStatusCode();
         var result = await response.Content.ReadFromJsonAsync<List<TrelloCard>>(ct).ConfigureAwait(false);
         return result?.Where(c => !string.IsNullOrEmpty(c.Id) && !string.IsNullOrEmpty(c.Name)).ToList() ?? [];
+    }
+
+    /// <summary>
+    /// Archives (closed=true) or un-archives a card. Returns true when the card
+    /// reached the desired state — including 404, which means the card is gone
+    /// on Trello's side and there is nothing left to close.
+    /// </summary>
+    public async Task<bool> SetCardClosedAsync(string cardId, bool closed, string apiKey, string token, CancellationToken ct = default)
+    {
+        using var req = Authorized(HttpMethod.Put,
+            $"{ApiBase}/cards/{Uri.EscapeDataString(cardId)}?closed={(closed ? "true" : "false")}", apiKey, token);
+        using var response = await Client.SendAsync(req, ct).ConfigureAwait(false);
+        return response.IsSuccessStatusCode || response.StatusCode == System.Net.HttpStatusCode.NotFound;
     }
 
     public async Task<List<(TrelloCard Card, string BoardName, string ListName)>> GetCardsInListByNameAsync(

--- a/DailyPlanner/ViewModels/MainViewModel.Trello.cs
+++ b/DailyPlanner/ViewModels/MainViewModel.Trello.cs
@@ -17,6 +17,7 @@ public partial class MainViewModel
         var s = await _service.GetTrelloSettingsAsync();
         s.IsEnabled = TrelloIsEnabled;
         s.AutoSyncOnStartup = TrelloAutoSyncOnStartup;
+        s.PushCompletions = TrelloPushCompletions;
         s.ApiKey = TrelloApiKey.Trim();
         s.Token = TrelloToken.Trim();
         s.ListName = string.IsNullOrWhiteSpace(TrelloListName) ? "В работе" : TrelloListName.Trim();

--- a/DailyPlanner/ViewModels/MainViewModel.cs
+++ b/DailyPlanner/ViewModels/MainViewModel.cs
@@ -59,6 +59,7 @@ public sealed partial class MainViewModel : ObservableObject
     private readonly TrelloService _trelloService;
     [ObservableProperty] private bool _trelloIsEnabled;
     [ObservableProperty] private bool _trelloAutoSyncOnStartup;
+    [ObservableProperty] private bool _trelloPushCompletions;
     [ObservableProperty] private string _trelloApiKey = string.Empty;
     [ObservableProperty] private string _trelloToken = string.Empty;
     [ObservableProperty] private string _trelloListName = "В работе";
@@ -595,6 +596,7 @@ public sealed partial class MainViewModel : ObservableObject
         var s = await _service.GetTrelloSettingsAsync();
         TrelloIsEnabled = s.IsEnabled;
         TrelloAutoSyncOnStartup = s.AutoSyncOnStartup;
+        TrelloPushCompletions = s.PushCompletions;
         TrelloApiKey = s.ApiKey;
         TrelloToken = s.Token;
         TrelloListName = string.IsNullOrWhiteSpace(s.ListName) ? "В работе" : s.ListName;
@@ -679,6 +681,23 @@ public sealed partial class MainViewModel : ObservableObject
         _ = EnsureAutoCreateEntriesAsync();
         _ = CheckSubscriptionRemindersAsync();
         _ = CheckSubscriptionAuditAsync();
+
+        // Two-way Trello: push completed/reopened tasks at most every 5 minutes.
+        // The push also rides along with every full sync; this keeps the lag
+        // bounded when the user just checks tasks off without syncing.
+        if (localNow - _lastTrelloPush >= TimeSpan.FromMinutes(5))
+        {
+            _lastTrelloPush = localNow;
+            PushTrelloCompletionsAsync().FireAndForget("TrelloPush");
+        }
+    }
+
+    private DateTimeOffset _lastTrelloPush = DateTimeOffset.MinValue;
+
+    private async Task PushTrelloCompletionsAsync()
+    {
+        try { await _service.PushCompletedToTrelloAsync(_trelloService); }
+        catch (Exception ex) { Log.Error("MainVM", $"Trello push failed: {ex.Message}"); }
     }
 
     /// <summary>

--- a/DailyPlanner/Views/SettingsPage.xaml
+++ b/DailyPlanner/Views/SettingsPage.xaml
@@ -124,7 +124,10 @@
                     <CheckBox Content="{Binding [Enabled], Source={x:Static svc:Loc.Instance}}"
                               IsChecked="{Binding TrelloIsEnabled}" Margin="0,0,0,4"/>
                     <CheckBox Content="{Binding [TrelloAutoSync], Source={x:Static svc:Loc.Instance}}"
-                              IsChecked="{Binding TrelloAutoSyncOnStartup}" Margin="0,0,0,10"
+                              IsChecked="{Binding TrelloAutoSyncOnStartup}" Margin="0,0,0,4"
+                              FontSize="12" Foreground="{DynamicResource MutedBrush}"/>
+                    <CheckBox Content="{Binding [TrelloPushCompletions], Source={x:Static svc:Loc.Instance}}"
+                              IsChecked="{Binding TrelloPushCompletions}" Margin="0,0,0,10"
                               FontSize="12" Foreground="{DynamicResource MutedBrush}"/>
 
                     <TextBlock Text="{Binding [TrelloApiKey], Source={x:Static svc:Loc.Instance}}" FontSize="12"


### PR DESCRIPTION
Opt-in push side for the Trello integration: completed tasks archive their card, un-completed tasks un-archive it. Stamped per task, retried on failure, no-op when disabled. Expand-only migration (2 columns).