### PR TITLE
Velopack 0.0.1589 -> 1.2.0

### DIFF
--- a/DailyPlanner.Tests/packages.lock.json
+++ b/DailyPlanner.Tests/packages.lock.json
@@ -302,8 +302,8 @@
       },
       "Velopack": {
         "type": "Transitive",
-        "resolved": "0.0.1589-ga2c5a97",
-        "contentHash": "PoHi9BgM+siDh0eSQUOy397fix2co66YrupZ1xtAf5RlUQNZYTaro0cGXPh+TIxwV8zHiUQ22Uh2NyAK9T3VEw=="
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
       },
       "WPF-UI": {
         "type": "Transitive",
@@ -366,7 +366,7 @@
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.7, )",
           "Microsoft.Extensions.DependencyInjection": "[10.0.7, )",
           "SQLitePCLRaw.lib.e_sqlite3": "[2.1.12, )",
-          "Velopack": "[0.0.1589-ga2c5a97, )",
+          "Velopack": "[1.2.0, )",
           "WPF-UI": "[4.2.1, )"
         }
       }

--- a/DailyPlanner/DailyPlanner.csproj
+++ b/DailyPlanner/DailyPlanner.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Velopack" Version="0.0.1589-ga2c5a97" />
+    <PackageReference Include="Velopack" Version="1.2.0" />
     <PackageReference Include="WPF-UI" Version="4.2.1" />
     <!-- Transitive pin: SQLitePCLRaw.lib.e_sqlite3 2.1.11 (pulled by EFCore.Sqlite) has a high-severity
          native SQLite vulnerability (NU1903, GHSA-2m69-gcr7-jv3q / CVE-2025-6965, memory corruption

--- a/DailyPlanner/packages.lock.json
+++ b/DailyPlanner/packages.lock.json
@@ -73,9 +73,9 @@
       },
       "Velopack": {
         "type": "Direct",
-        "requested": "[0.0.1589-ga2c5a97, )",
-        "resolved": "0.0.1589-ga2c5a97",
-        "contentHash": "PoHi9BgM+siDh0eSQUOy397fix2co66YrupZ1xtAf5RlUQNZYTaro0cGXPh+TIxwV8zHiUQ22Uh2NyAK9T3VEw=="
+        "requested": "[1.2.0, )",
+        "resolved": "1.2.0",
+        "contentHash": "Rz67gJL619fSBS6omaSINUxyDuwhIxkm5mmubf7uLd5Qgi6LLKaKCha+QFP6n+Bw/UjA0vutnH4JQfYzn6ANtw=="
       },
       "WPF-UI": {
         "type": "Direct",


### PR DESCRIPTION
Dependency bump previously proposed by Dependabot (#90), done as a dedicated pass. API unchanged, builds and tests green. The next release must be packed with vpk 1.2.x (matching tool version), and the first client auto-update through the 0.x -> 1.x boundary deserves a manual sanity check.